### PR TITLE
[Tel-186] clicking logo in call opens marketing site

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <!--#include virtual="base.html" -->
 
     <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
-    <link rel="stylesheet" href="css/all.css?v=146">
+    <link rel="stylesheet" href="css/all.css?v=149">
 
     <script>
         // IE11 and earlier can be identified via their user agent and be
@@ -146,8 +146,8 @@
     <script src="libs/do_external_connect.min.js?v=2"></script>
     <script><!--#include virtual="/interface_config.js" --></script>
     <script><!--#include virtual="/logging_config.js" --></script>
-    <script src="libs/lib-jitsi-meet.min.js?v=146"></script>
-    <script src="libs/app.bundle.min.js?v=146"></script>
+    <script src="libs/lib-jitsi-meet.min.js?v=149"></script>
+    <script src="libs/app.bundle.min.js?v=149"></script>
     <!--#include virtual="title.html" -->
     <!--#include virtual="plugin.head.html" -->
     <!--#include virtual="static/welcomePageAdditionalContent.html" -->

--- a/react/features/base/react/components/web/Watermarks.js
+++ b/react/features/base/react/components/web/Watermarks.js
@@ -183,13 +183,15 @@ class Watermarks extends Component<Props, State> {
         //
         //     if (jitsiWatermarkLink) {
         //         reactElement = (
-        //             { reactElement }
+        //             <a
+        //                 href = { "http://jane.app" }
+        //                 target = '_new'>
+        //                 { reactElement }
+        //             </a>
         //         );
         //     }
         // }
-        //
-        // return reactElement;
-        return <div className = 'watermark leftwatermark' />;
+        return <div className = 'watermark leftwatermark' />;;
     }
 
     /**

--- a/react/features/base/react/components/web/Watermarks.js
+++ b/react/features/base/react/components/web/Watermarks.js
@@ -172,27 +172,24 @@ class Watermarks extends Component<Props, State> {
      * @returns {ReactElement|null}
      */
     _renderJitsiWatermark() {
-        let reactElement = null;
-
-        if (this.state.showJitsiWatermark
-                || (this.props._isGuest
-                    && this.state.showJitsiWatermarkForGuests)) {
-            reactElement = <div className = 'watermark leftwatermark' />;
-
-            const { jitsiWatermarkLink } = this.state;
-
-            if (jitsiWatermarkLink) {
-                reactElement = (
-                    <a
-                        href = { "http://jane.app" }
-                        target = '_new'>
-                        { reactElement }
-                    </a>
-                );
-            }
-        }
-
-        return reactElement;
+        // let reactElement = null;
+        //
+        // if (this.state.showJitsiWatermark
+        //         || (this.props._isGuest
+        //             && this.state.showJitsiWatermarkForGuests)) {
+        //     reactElement = <div className = 'watermark leftwatermark' />;
+        //
+        //     const { jitsiWatermarkLink } = this.state;
+        //
+        //     if (jitsiWatermarkLink) {
+        //         reactElement = (
+        //             { reactElement }
+        //         );
+        //     }
+        // }
+        //
+        // return reactElement;
+        return <div className = 'watermark leftwatermark' />;
     }
 
     /**


### PR DESCRIPTION
[Jira issue](https://janeapp.atlassian.net/browse/TEL-186)

- Remove the "a" link from the top left jane watermark logo.

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [ ] I added tests for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`
- [ ] I confirmed that all CircleCI tests are passing
- [x] I didn't add new npm packages, or else I made damn sure the `yarn.lock` changes are safe for existing production packages

## QA and Smoke Testing
Click on the top left jane logo => should not redirect to jane.