### PR TITLE
Fix toISOString TypeError error when leaving meeting & update the webpack config

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -399,7 +399,7 @@ export function conferenceWillLeave(conference: Object) {
         const { jwt } = APP.store.getState()['features/base/jwt'];
         const { conferenceStartedTime } = APP.store.getState()['features/base/conference'];
 
-        if (jwt) {
+        if (jwt && conferenceStartedTime) {
             const jwtPayload = jwtDecode(jwt);
             const leaveUrl = jwtPayload.context.leave_url || null;
             const surveyUrl = jwtPayload.context.survey_url || null;
@@ -411,7 +411,7 @@ export function conferenceWillLeave(conference: Object) {
             const data = new Blob([ JSON.stringify(obj, null, 2) ], { type: 'text/plain; charset=UTF-8' });
             // eslint-disable-next-line no-mixed-operators
 
-            if (leaveUrl && surveyUrl && conferenceStartedTime) {
+            if (leaveUrl && surveyUrl) {
                 navigator.sendBeacon(leaveUrl, data);
             }
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,15 @@ const minimize
     = process.argv.indexOf('-p') !== -1
         || process.argv.indexOf('--optimize-minimize') !== -1;
 
+const generateIndexHtml = new HtmlWebpackPlugin({
+    jitsiLib: `libs/lib-jitsi-meet.min.js?v=${cacheVersionNumber}`,
+    appBundle: `libs/app.bundle.min.js?v=${cacheVersionNumber}`,
+    css: `css/all.css?v=${cacheVersionNumber}`,
+    template: 'index.html',
+    minify: false,
+    inject: false
+})
+
 /**
  * Build a Performance configuration object for the given size.
  * See: https://webpack.js.org/configuration/performance/
@@ -156,17 +165,9 @@ const config = {
     },
     plugins: [
         analyzeBundle
-            && new BundleAnalyzerPlugin({
-                analyzerMode: 'disabled',
-                generateStatsFile: true
-            }),
-        new HtmlWebpackPlugin({
-            jitsiLib: `libs/lib-jitsi-meet.min.js?v=${cacheVersionNumber}`,
-            appBundle: `libs/app.bundle.min.js?v=${cacheVersionNumber}`,
-            css: `css/all.css?v=${cacheVersionNumber}`,
-            template: 'index.html',
-            minify: false,
-            inject: false
+        && new BundleAnalyzerPlugin({
+            analyzerMode: 'disabled',
+            generateStatsFile: true
         })
     ].filter(Boolean),
     resolve: {
@@ -186,8 +187,10 @@ const config = {
     }
 };
 
+const appBundleConfig = {...config, plugins: [...config.plugins, generateIndexHtml]};
+
 module.exports = [
-    Object.assign({}, config, {
+    Object.assign({}, appBundleConfig, {
         entry: {
             'app.bundle': './app.js'
         },


### PR DESCRIPTION
## Description
I found a bug on bugsnag:
![image](https://user-images.githubusercontent.com/24568041/84688296-f93c8380-aef3-11ea-9e88-2fe844072122.png)

Solution:
- update the condition in `send leave beacon` code block in `conferenceWillLeave` action function.

Webpack update(not related to this bug):
- update the webpack config file and the webpack will only generate the index HTML file from the template when it is bundling the `app.js`. 

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [ ] I added tests for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`
- [ ] I confirmed that all CircleCI tests are passing
- [x] I didn't add new npm packages, or else I made damn sure the `yarn.lock` changes are safe for existing production packages

## QA and Smoke Testing
- Create an online appointment.
- Open browser dev tool > **Network**
- Click on the online appointment in the calendar
- Copy the links from here:

![image](https://user-images.githubusercontent.com/24568041/84691639-5ab32100-aef9-11ea-9cdf-c0c3d8ef0cce.png)

- Convert the link to `https` protocol like this:
`//videochat-jwt.jane.qa/.....` > `https://videochat-jwt.jane.qa/...`
- paste the URL to browser address bar and join the call
- hang up the call
- the console will **not** show:
![image](https://user-images.githubusercontent.com/24568041/84689283-9ea42700-aef5-11ea-8f4d-e307ac7a9118.png)


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/24568041/84689301-a663cb80-aef5-11ea-9faa-9926eb45cb88.png)

### After
No more `TypeError: Cannot read property 'toISOString' of undefined`


