### PR TITLE
[TRON-57] Disable screen-sharing in Jane Desktop video-chat

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 // @flow
-
+import JitsiMeetJS from '../../../base/lib-jitsi-meet';
 import React, { Component } from 'react';
 
 import {

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1247,7 +1247,7 @@ class Toolbox extends Component<Props, State> {
         overflowMenuContent.splice(
             1, 0, ...this._renderMovedButtons(movedButtons));
 
-        const showDesktopSharingButton = this.state.windowWidth > 475;
+        const showDesktopSharingButton = this.state.windowWidth > 475 && !JitsiMeetJS.util.browser.isElectron();
 
         return (
             <div className = 'toolbox-content'>


### PR DESCRIPTION
## Description
- Disable screen-sharing feature in Electron by removing the `dekstop sharing` button in `ToolBox` component

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [ ] I added tests for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`
- [ ] I confirmed that all CircleCI tests are passing
- [x] I didn't add new npm packages, or else I made damn sure the `yarn.lock` changes are safe for existing production packages

## QA and Smoke Testing
- Join an online appointment in Jane Desktop
- the "share your screen" button should be invisible.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/24568041/84833491-3c761f80-afe4-11ea-885b-ce4138f0af5b.png)

### After

![image](https://user-images.githubusercontent.com/24568041/84833469-308a5d80-afe4-11ea-84dd-62ff5d8da310.png)

