### PR TITLE
[TEL-294] Improve CPU Utilization to improve Telehealth experience(web)

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -9,7 +9,7 @@ var interfaceConfig = {
      * Whether or not the blurred video background for large video should be
      * displayed on browsers that can support it.
      */
-    DISABLE_VIDEO_BACKGROUND: false,
+    DISABLE_VIDEO_BACKGROUND: true,
 
     INITIAL_TOOLBAR_TIMEOUT: 20000,
     TOOLBAR_TIMEOUT: 4000,

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -60,7 +60,7 @@ export default class LocalVideo extends SmallVideo {
         // 'local' if no id has been assigned yet.
         this.initializeAvatar();
 
-        this.addAudioLevelIndicator();
+        // this.addAudioLevelIndicator();
         this.updateIndicators();
 
         this.container.onclick = this._onContainerClick;

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -131,7 +131,7 @@ export default class RemoteVideo extends SmallVideo {
         this.initBrowserSpecificProperties();
         this.updateRemoteVideoMenu();
         this.updateStatusBar();
-        this.addAudioLevelIndicator();
+        // this.addAudioLevelIndicator();
         this.addPresenceLabel();
 
         return this.container;


### PR DESCRIPTION
## Description
- [Jira Ticket](https://janeapp.atlassian.net/browse/TEL-294)

We were seeing high CPU utilization on some clients' machines. To resolve this issue we decided to disable/remove the following feature/settings:

- disabling H.264 codec (related to hardware acceleration) on the back-end side.

- disabling video backgrounds in FE.

- remove the `AudioLevelIndicator` component from `LargeVideo` & `RemoteVideo` component.



🏇 = Performance improvement



### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [ ] I added tests for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`
- [x] I confirmed that all CircleCI tests are passing
- [ ] I didn't add new npm packages, or else I made damn sure the `yarn.lock` changes are safe for existing production packages

## QA and Smoke Testing
### Steps to Reproduce

Please use `https://videochat.jane.qa/someroomname` for QA

- the video background(the blurry background) should be removed.

- the small video window would not show the audio level indicator(blue dots) when the user is speaking.

### Jitsi backend update

- set `disableH264=true` in `config.js` file (2 locations in config.js) for disabling H.264 codec (related to hardware acceleration)

## Screenshots
## Before:

![image](https://user-images.githubusercontent.com/24568041/97946006-0260ac80-1d3e-11eb-83f5-4d3f471a82d0.png)

## After:

![image](https://user-images.githubusercontent.com/24568041/97946291-d691f680-1d3e-11eb-9064-af9acf5e2222.png)

