### PR TITLE
[Fix] Video not displaying even when turned on

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -132,6 +132,7 @@ import { endpointMessageReceived } from './react/features/subtitles';
 import UIEvents from './service/UI/UIEvents';
 import * as RemoteControlEvents
     from './service/remotecontrol/RemoteControlEvents';
+import { _setSenderVideoConstraint } from './react/features/video-quality/middleware';
 
 const logger = Logger.getLogger(__filename);
 
@@ -1296,6 +1297,12 @@ export default {
             = connection.initJitsiConference(
                 APP.conference.roomName,
                 this._getConferenceOptions());
+
+        // Temporary fix: If layer suspension is disabled and sender constraint is not configured for the conference,
+        // Jitsi may stop encoding the sender's video track.
+        // So we can set a sender video constraint here to fix the issue.
+        // https://github.com/jitsi/lib-jitsi-meet/issues/1333
+        _setSenderVideoConstraint(room, 720)
 
         APP.store.dispatch(conferenceWillJoin(room));
         this._setLocalAudioVideoStreams(localTracks);

--- a/conference.js
+++ b/conference.js
@@ -129,10 +129,10 @@ import { setSharedVideoStatus } from './react/features/shared-video';
 import { AudioMixerEffect } from './react/features/stream-effects/audio-mixer/AudioMixerEffect';
 import { createPresenterEffect } from './react/features/stream-effects/presenter';
 import { endpointMessageReceived } from './react/features/subtitles';
+import { _setSenderVideoConstraint } from './react/features/video-quality/middleware';
 import UIEvents from './service/UI/UIEvents';
 import * as RemoteControlEvents
     from './service/remotecontrol/RemoteControlEvents';
-import { _setSenderVideoConstraint } from './react/features/video-quality/middleware';
 
 const logger = Logger.getLogger(__filename);
 
@@ -1302,7 +1302,7 @@ export default {
         // Jitsi may stop encoding the sender's video track.
         // So we can set a sender video constraint here to fix the issue.
         // https://github.com/jitsi/lib-jitsi-meet/issues/1333
-        _setSenderVideoConstraint(room, 720)
+        _setSenderVideoConstraint(room, 720);
 
         APP.store.dispatch(conferenceWillJoin(room));
         this._setLocalAudioVideoStreams(localTracks);

--- a/react/features/video-quality/middleware.js
+++ b/react/features/video-quality/middleware.js
@@ -141,7 +141,7 @@ function _setReceiverVideoConstraint(conference, preferred, max) {
  * @param {number} preferred - The user preferred max frame height.
  * @returns {void}
  */
-export function _setSenderVideoConstraint(conference, preferred) {
+export function _setSenderVideoConstraint(conference: Object, preferred: number) {
     if (conference) {
         conference.setSenderVideoConstraint(preferred)
             .catch(err => {

--- a/react/features/video-quality/middleware.js
+++ b/react/features/video-quality/middleware.js
@@ -141,7 +141,7 @@ function _setReceiverVideoConstraint(conference, preferred, max) {
  * @param {number} preferred - The user preferred max frame height.
  * @returns {void}
  */
-function _setSenderVideoConstraint(conference, preferred) {
+export function _setSenderVideoConstraint(conference, preferred) {
     if (conference) {
         conference.setSenderVideoConstraint(preferred)
             .catch(err => {


### PR DESCRIPTION
## Description
[notion](https://www.notion.so/janeapp/Video-not-displaying-even-when-turned-on-c9a988f2d5df46888a7a02a834cfc40a)

### Issue:
Some participant will have their video on (can see themselves) but to the other participant, it will appear that their video is either off (shows initials) or is all black. (After the 5076 upgrade)

### Cause:
Jitsi updated their `lib-jitsi-meet` library code in August for the "layer suspension" feature. This update caused the app to stop encoding the sender's video track occasionally(can not get the sender video height properly.) if the app doesn't have the layerSuspension config option enabled.

more info: https://github.com/jitsi/lib-jitsi-meet/issues/1333#issuecomment-708513033

### Fix:
Set sender video constraint to 720 when user joining the conference to avoid the `null` sender video height issue.

### Note:
Jitsi included a fix in release `2.0.5390` (21-01-12)
https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-WEB.md

We may need to remove this fix when we upgrade the app to 5390.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note
> Describe here a CS friendly version of what this fixes/adds. If the change is behind a feature flag, please include that in your description. If this is a hidden change CS doesn't need to really know about then just say so.

### Dependencies / ENV
> Describe any dependencies or ENV variables that are required for this change. Notify the team, if they have to update their environment.

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low 

### Demo Notes
it is a behind-the-scenes fix, Can not be demoed.

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
> - Add steps on how to reproduce the problem and how to test
> - ie. Create Appointment > Clicked Arrived > Pay > Look for "this"

### Fixed / Expected Behaviour
it is a behind-the-scenes fix, Smoke test on the video chat web app.

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After
