### PR TITLE
[IMPT-3, IMPT-353][IOS] Create custom events & property for sending more participant's statistics data to amplitude

### DIFF
--- a/react/features/analytics/AnalyticsEvents.js
+++ b/react/features/analytics/AnalyticsEvents.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 /**
  * The constant for the event type 'track'.
  * TODO: keep these constants in a single place. Can we import them from
@@ -769,4 +770,40 @@ export function createWelcomePageEvent(action, actionSubject, attributes = {}) {
         attributes,
         source: 'welcomePage'
     };
+}
+
+/**
+ * Creates an event which indicates that connection strength was changed.
+ *
+ * @param {string} strength - The subject that was acted upon.
+ * @param {Object} stats - Additional attributes to attach to the event.
+ * @returns {Object} The event in a format suitable for sending via
+ * sendAnalytics.
+ */
+export function createConnectionQualityChangedEvent(strength, stats) {
+    return {
+        action: 'connection.quality.changed',
+        attributes: {
+            bandwidth: stats.bandwidth,
+            bitrate: stats.bitrate,
+            bridgeCount: stats.bridgeCount,
+            codec: removeTrackIdFromEventPropertyObject(stats.codec),
+            connectionQuality: stats.connectionQuality,
+            framerate: removeTrackIdFromEventPropertyObject(stats.framerate),
+            packetLoss: stats.packetLoss,
+            resolution: removeTrackIdFromEventPropertyObject(stats.resolution),
+            strength
+        }
+    };
+}
+
+/**
+ * Remove the track id from the ConnectionQualityChangedEvent property.
+ * If we don't want to send the trackId along with the property to amplitude.
+ *
+ * @param {Object} event - event object.
+ * @returns {Object|number|string|undefined} property.
+ */
+function removeTrackIdFromEventPropertyObject(event) {
+    return event && _.isObject(event) && Object.values(event)[0];
 }

--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -5,6 +5,7 @@ import JitsiMeetJS, {
     browser,
     isAnalyticsEnabled
 } from '../base/lib-jitsi-meet';
+import { getLocalParticipantType } from '../base/participants';
 import { getJitsiMeetGlobalNS, loadScript } from '../base/util';
 import {
     checkChromeExtensionsInstalled,
@@ -140,9 +141,10 @@ export function initAnalytics({ getState }: { getState: Function }, handlers: Ar
         permanentProperties.group = group;
     }
 
+    permanentProperties.participantType = getLocalParticipantType(state);
+
     //  Report if user is using websocket
     permanentProperties.websocket = navigator.product !== 'ReactNative' && typeof config.websocket === 'string';
-
     // Optionally, include local deployment information based on the
     // contents of window.config.deploymentInfo.
     if (deploymentInfo) {

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -1,6 +1,6 @@
 // @flow
 import { getGravatarURL } from 'js-utils/avatar';
-
+import jwtDecode from 'jwt-decode';
 import { toState } from '../redux';
 
 import { JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
@@ -375,4 +375,31 @@ async function _getFirstLoadableAvatarUrl(participant) {
     }
 
     return undefined;
+}
+
+/**
+ * Returns participant info from the jwt token
+ *
+ * @param {Object|Function} state - Object or function that can be resolved
+ * to the Redux state.
+ * @returns {string|null}
+ */
+export function getLocalParticipantFromJwt(state: Object | Function): Object {
+    const { jwt } = state['features/base/jwt'];
+    const jwtPayload = jwt && jwtDecode(jwt) ?? null;
+
+    return jwtPayload && jwtPayload.context && jwtPayload.context.user ?? null;
+}
+
+/**
+ * Returns participant type from the participant info
+ *
+ * @param {Object|Function} state - Object or function that can be resolved
+ * to the Redux state.
+ * @returns {string|null}
+ */
+export function getLocalParticipantType(state: Object | Function): string {
+    const participant = getLocalParticipantFromJwt(state);
+
+    return participant && participant.participant_type ?? null;
 }

--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -2,6 +2,7 @@
 
 import _ from 'lodash';
 
+import { createConnectionQualityChangedEvent, sendAnalytics } from '../analytics';
 import {
     JitsiConnectionQualityEvents,
     JitsiE2ePingEvents
@@ -15,6 +16,23 @@ import {
  * }
  */
 const subscribers = {};
+
+let localConnectionStrength = null;
+
+const CONNECTION_QUALITY_STRENGTH: Array<Object> = [
+    {
+        connectionQuality: 30,
+        strength: 'good'
+    },
+    {
+        connectionQuality: 10,
+        strength: 'nonoptimal'
+    },
+    {
+        connectionQuality: 0,
+        strength: 'poor'
+    }
+];
 
 /**
  * A singleton that acts as a pub/sub service for connection stat updates.
@@ -132,6 +150,19 @@ const statsEmitter = {
             resolution: allUserResolutions[localUserId]
         });
 
+        // send local stats data to amplitude if local user's connection strength was changed.
+        if (modifiedLocalStats.connectionQuality) {
+            const modifiedLocalConnectionStrength = this._getConnectionQuality(modifiedLocalStats.connectionQuality)
+                .strength;
+
+            if (localConnectionStrength !== modifiedLocalConnectionStrength) {
+                localConnectionStrength = modifiedLocalConnectionStrength;
+                sendAnalytics(createConnectionQualityChangedEvent(
+                    modifiedLocalConnectionStrength,
+                    modifiedLocalStats));
+            }
+        }
+
         this._emitStatsUpdate(localUserId, modifiedLocalStats);
 
         // Get all the unique user ids from the framerate and resolution stats
@@ -158,6 +189,10 @@ const statsEmitter = {
 
                 this._emitStatsUpdate(id, remoteUserStats);
             });
+    },
+
+    _getConnectionQuality(connectionQuality: number): Object {
+        return CONNECTION_QUALITY_STRENGTH.find(x => connectionQuality >= x.connectionQuality) || {};
     }
 };
 


### PR DESCRIPTION
## Description

### This PR is for react native app. The updates/changes are the same as the PR https://github.com/janeapp/video-chat/pull/38

- [Linear Ticket](https://linear.app/jane/issue/IMPT-3/create-custom-events-and-property-for-sending-more-participants)

In order to measure the call quality and determine what might be causing issues in a call. We decided to add a custom amplitude event & a custom amplitude property to jitsi.

- Create a "connection.quality.changed" custom event to send local participant's connection statistics data to amplitude if the user's network connection strength changes.

- Add a `participantType` permanent property to identify the user type to all amplitude events.

### General PR Class
🏇 = Performance improvement


### Release Note
> Describe here a CS friendly version of what this fixes/adds. If the change is behind a feature flag, please include that in your description. If this is a hidden change CS doesn't need to really know about then just say so.

### Dependencies / ENV
> Describe any dependencies or ENV variables that are required for this change. Notify the team, if they have to update their environment.

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Very very low risk.

### Demo Notes
https://www.loom.com/share/06d8c209a1694a74aee0fcd33e00828e

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [ ] I added specs for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
Download jane online appointment app from TestFlight -> Create an online appointment -> join the conference as the practitioner & the patient on ios devices -> wait until the p2p connection is established -> go to amplitude -> search the conference events. -> you can find `connection.quality.changed` event & `participantType` property.

### Fixed / Expected Behaviour
we can find the quality changed events that were sent from ios in amplitude. 

![image](https://user-images.githubusercontent.com/24568041/107428293-47cc0d00-6ad7-11eb-891f-534c3262bd6f.png)

a new custom property to all amplitude events: `participantType`
![image](https://user-images.githubusercontent.com/24568041/104686530-3f3c0e80-56b2-11eb-8f40-78821e56fb38.png)


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After
