### PR TITLE
[IMPT-398] Only send the Poor connection events to Amplitude

### DIFF
--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -159,9 +159,11 @@ const statsEmitter = {
 
             if (localConnectionStrength !== modifiedLocalConnectionStrength) {
                 localConnectionStrength = modifiedLocalConnectionStrength;
-                sendAnalytics(createConnectionQualityChangedEvent(
-                    modifiedLocalConnectionStrength,
-                    modifiedLocalStats));
+                if (localConnectionStrength === 'poor') {
+                    sendAnalytics(createConnectionQualityChangedEvent(
+                        modifiedLocalConnectionStrength,
+                        modifiedLocalStats));
+                }
             }
         }
 


### PR DESCRIPTION
## Description
We're hitting our Amplitude event limit and most are coming form the connection quality event. Let's reduce what we're collecting so we only send the connection.quality.changed event if it is poor. This would still allow us to see when users have a poor connection. 

[Linear ticket](https://linear.app/jane/issue/IMPT-398/only-send-the-poor-connection-events-to-amplitude)

### General PR Class
🏇 = Performance improvement

### Release Note

### Dependencies / ENV
N/A

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Very Low

### Demo Notes
https://www.loom.com/share/da167ffaadd34995b75766fe715bf4f6

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
Smoke test only. We're not able to test this PR due to we could not throttle the internet speed on the real ios device.
