### PR TITLE
[IMPT-362] Pad the video so it can be a max of N pixels

### DIFF
--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -640,18 +640,13 @@ export default class LargeVideoManager {
      * @returns {void}
      */
     _onVideoResolutionUpdate() {
-        const { height, width } = this.videoContainer.getStreamSize();
+        const { height } = this.videoContainer.getStreamSize();
         const { resolution } = APP.store.getState()['features/large-video'];
 
         if (height !== resolution) {
             APP.store.dispatch(updateKnownLargeVideoResolution(height));
         }
 
-        const currentAspectRatio = height === 0 ? 0 : width / height;
-
-        if (this._videoAspectRatio !== currentAspectRatio) {
-            this._videoAspectRatio = currentAspectRatio;
-            this.resize();
-        }
+        this.resize();
     }
 }

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -23,6 +23,9 @@ const SD_VIDEO_CONTAINER_HEIGHT = VIDEO_QUALITY_LEVELS.STANDARD;
 const SD_VIDEO_CONTAINER_PADDING_PERCENTAGE = 0.1;
 const SD_VIDEO_CONTAINER_PADDING_BREAKPOINT = 768;
 
+// minimum top padding + bottom padding
+const SD_VIDEO_CONTAINER_MIN_VERTICAL_PADDING = 248;
+
 /**
  * Returns an array of the video dimensions, so that it keeps it's aspect
  * ratio and fits available area with it's larger dimension. This method
@@ -120,6 +123,10 @@ function computeCameraVideoSize( // eslint-disable-line max-params
         if (width > maxWidth) {
             width = maxWidth < SD_VIDEO_CONTAINER_PADDING_BREAKPOINT ? maxWidth : maxWidth - horizontalPadding;
             height = width / aspectRatio;
+            if (maxZoomCoefficient === 1) {
+                // If the video feed is in SD, fix the height to avoid overlapping with Jane's logo
+                height = maxHeight - verticalPadding;
+            }
         } else if (height > maxHeight) {
             height = maxHeight - verticalPadding;
             width = height * aspectRatio;
@@ -158,8 +165,12 @@ function getMaxZoomCoefficient(videoHeight) {
  */
 function getPaddings(videoSpaceHeight, videoSpaceWidth, videoHeight) {
     if (videoHeight <= SD_VIDEO_CONTAINER_HEIGHT) {
-        const verticalPadding = videoSpaceHeight * SD_VIDEO_CONTAINER_PADDING_PERCENTAGE * 2;
+        let verticalPadding = videoSpaceHeight * SD_VIDEO_CONTAINER_PADDING_PERCENTAGE * 2;
         const horizontalPadding = videoSpaceWidth * SD_VIDEO_CONTAINER_PADDING_PERCENTAGE * 2;
+
+        if (verticalPadding < SD_VIDEO_CONTAINER_MIN_VERTICAL_PADDING) {
+            verticalPadding = SD_VIDEO_CONTAINER_MIN_VERTICAL_PADDING;
+        }
 
         return [ verticalPadding, horizontalPadding ];
     }


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/IMPT-362/pad-the-video-so-it-can-be-a-max-of-n-pixels)

We want to pad the video for SD so we can maintain the video pixel density and it won't look blurry when users maximize the video call window. The padding will be only added to desktop & tablet browsers. 

- add 10% padding for all four sides of the SD video container only. (not for the HD)
- only add padding if the screen width > 768px (for tablet & desktop device)

### General PR Class
👁 = UX / UI improvement

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes
https://www.loom.com/share/f5ae6ff2f70846f4bc20e5ca05327fca

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
Please make sure the`Telehealth Selectable HD quality` beta flag is disabled > Create an online appointment > join the call > the video feed container should be padded

### Fixed / Expected Behaviour

<img src='https://user-images.githubusercontent.com/24568041/113205859-98343100-9223-11eb-9800-432eb11444c8.png' width=500>


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before

<img src='https://user-images.githubusercontent.com/24568041/113205367-12b08100-9223-11eb-8a0d-b953d79eb61e.png' width=500>
### After
<img src='https://user-images.githubusercontent.com/24568041/113205859-98343100-9223-11eb-9800-432eb11444c8.png' width=500>
