### PR TITLE
[SCH-263] HD video quality alert

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -76,6 +76,7 @@ import {
 import {
     dominantSpeakerChanged,
     getLocalParticipant,
+    getLocalParticipantType,
     getNormalizedDisplayName,
     getParticipantById,
     localParticipantConnectionStatusChanged,
@@ -102,7 +103,8 @@ import {
     isUserInteractionRequiredForUnmute,
     replaceLocalTrack,
     trackAdded,
-    trackRemoved
+    trackRemoved,
+    isHdQualityEnabled
 } from './react/features/base/tracks';
 import {
     getBackendSafePath,
@@ -129,6 +131,7 @@ import { setSharedVideoStatus } from './react/features/shared-video';
 import { AudioMixerEffect } from './react/features/stream-effects/audio-mixer/AudioMixerEffect';
 import { createPresenterEffect } from './react/features/stream-effects/presenter';
 import { endpointMessageReceived } from './react/features/subtitles';
+import { setPreferredVideoQuality } from './react/features/video-quality';
 import { _setSenderVideoConstraint } from './react/features/video-quality/middleware';
 import UIEvents from './service/UI/UIEvents';
 import * as RemoteControlEvents
@@ -715,6 +718,17 @@ export default {
                 descriptionKey: 'notify.startSilentDescription',
                 titleKey: 'notify.startSilentTitle'
             }));
+        }
+
+        if (!JitsiMeetJS.util.browser.isFirefox()
+                && isHdQualityEnabled(APP.store.getState())
+                && getLocalParticipantType(APP.store.getState()) === 'StaffMember') {
+
+            // If the pratitioner turns on the HD quality in Jane.
+            // We will still limit the quality to SD(360) at the beginning
+            // the pratitioner can change the quality to HD(720) through hd quality alert
+            // or the video quality control modal.
+            APP.store.dispatch(setPreferredVideoQuality(360));
         }
 
         // XXX The API will take care of disconnecting from the XMPP

--- a/conference.js
+++ b/conference.js
@@ -724,9 +724,9 @@ export default {
                 && isHdQualityEnabled(APP.store.getState())
                 && getLocalParticipantType(APP.store.getState()) === 'StaffMember') {
 
-            // If the pratitioner turns on the HD quality in Jane.
+            // If the practitioner turns on the HD quality in Jane.
             // We will still limit the quality to SD(360) at the beginning
-            // the pratitioner can change the quality to HD(720) through hd quality alert
+            // the practitioner can change the quality to HD(720) through hd quality alert
             // or the video quality control modal.
             APP.store.dispatch(setPreferredVideoQuality(360));
         }

--- a/css/_hd-video-alert.scss
+++ b/css/_hd-video-alert.scss
@@ -1,0 +1,17 @@
+.hd-video-alert {
+    width: 100%;
+    position: absolute;
+    bottom: 100px;
+    left: 0;
+    z-index: 300;
+
+    &-container {
+        max-width: 300px;
+        margin: auto;
+    }
+
+    .button{
+        background-color: #FFFFFF;
+        color: #5e6d7a !important;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -103,5 +103,6 @@ $flagsImagePath: "../images/";
 @import 'e2ee';
 @import 'responsive';
 @import 'connection-status';
+@import "hd-video-alert";
 
 /* Modules END */

--- a/css/main.scss
+++ b/css/main.scss
@@ -103,6 +103,6 @@ $flagsImagePath: "../images/";
 @import 'e2ee';
 @import 'responsive';
 @import 'connection-status';
-@import "hd-video-alert";
+@import 'hd-video-alert';
 
 /* Modules END */

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -11,6 +11,21 @@ import {
 import loadEffects from './loadEffects';
 import logger from './logger';
 
+const HD_VIDEO_CONSTRAINTS = {
+    video: {
+        frameRate: {
+            ideal: 15,
+            max: 15,
+            min: 15
+        },
+        height: {
+            ideal: 720,
+            max: 720,
+            min: 240
+        }
+    }
+};
+
 /**
  * Creates a local video track for presenter. The constraints are computed based
  * on the height of the desktop that is being shared.
@@ -98,8 +113,12 @@ export function createLocalTracksF(options = {}, firePermissionPromptIsShownEven
 
     const hdQualityEnabled = isHdQualityEnabled(state);
 
-    if (JitsiMeetJS.util.browser.isFirefox() || hdQualityEnabled) {
+    if (JitsiMeetJS.util.browser.isFirefox()) {
         constraints = null;
+    }
+
+    if (!JitsiMeetJS.util.browser.isFirefox() && hdQualityEnabled) {
+        constraints = HD_VIDEO_CONSTRAINTS;
     }
 
     return (

--- a/react/features/conference/components/AbstractConference.js
+++ b/react/features/conference/components/AbstractConference.js
@@ -2,7 +2,14 @@
 
 import React, { Component } from 'react';
 
+import {
+    getLocalParticipantType,
+    getParticipantCount
+} from '../../base/participants';
+import { getRemoteTracks, isHdQualityEnabled } from '../../base/tracks';
 import { NotificationsContainer } from '../../notifications/components';
+import HdVideoAlert
+    from '../../notifications/components/web/HdVideoAlert';
 import { shouldDisplayTileView } from '../../video-layout';
 import { shouldDisplayNotifications } from '../functions';
 
@@ -33,7 +40,31 @@ export type AbstractProps = {
      * @protected
      * @type {boolean}
      */
-    _shouldDisplayTileView: boolean
+    _shouldDisplayTileView: boolean,
+
+    /**
+     * Whether or not the hd video feature is enabled.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    _hdVideoEnabled: boolean,
+
+    /**
+     * Whether or not the local participant is a practitioner.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    _isStaffMember: boolean,
+
+    /**
+     * Whether or not the conference has started.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    _conferenceHasStarted: boolean
 };
 
 /**
@@ -62,6 +93,22 @@ export class AbstractConference<P: AbstractProps, S>
 
         return null;
     }
+
+    /**
+     * Renders the {@code HdVideoAlert}.
+     *
+     * @protected
+     * @returns {React$Element}
+     */
+    renderHdVideoAlert() {
+        if (this.props._hdVideoEnabled
+            && this.props._isStaffMember
+            && this.props._conferenceHasStarted) {
+            return <HdVideoAlert />;
+        }
+
+        return null;
+    }
 }
 
 /**
@@ -73,9 +120,15 @@ export class AbstractConference<P: AbstractProps, S>
  * @returns {AbstractProps}
  */
 export function abstractMapStateToProps(state: Object) {
+    const participantCount = getParticipantCount(state);
+    const remoteTracks = getRemoteTracks(state['features/base/tracks']);
+
     return {
         _notificationsVisible: shouldDisplayNotifications(state),
         _room: state['features/base/conference'].room,
-        _shouldDisplayTileView: shouldDisplayTileView(state)
+        _shouldDisplayTileView: shouldDisplayTileView(state),
+        _hdVideoEnabled: isHdQualityEnabled(state),
+        _isStaffMember: getLocalParticipantType(state) === 'StaffMember',
+        _conferenceHasStarted: participantCount > 1 && remoteTracks.length > 0
     };
 }

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -206,6 +206,7 @@ class Conference extends AbstractConference<Props, *> {
                 { filmstripOnly || <Chat /> }
 
                 { this.renderNotificationsContainer() }
+                { this.renderHdVideoAlert() }
 
                 <CalleeInfoContainer />
 

--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -7,6 +7,7 @@ import {
     JitsiConnectionQualityEvents,
     JitsiE2ePingEvents
 } from '../base/lib-jitsi-meet';
+import { setHdVideoAlertEnabled } from '../notifications';
 
 /**
  * Contains all the callbacks to be notified when stats are updated.
@@ -156,6 +157,15 @@ const statsEmitter = {
         if (modifiedLocalStats.connectionQuality) {
             const modifiedLocalConnectionStrength = this._getConnectionQuality(modifiedLocalStats.connectionQuality)
                 .strength;
+            const modifiedLocalConnectionBitrate = this._getBandWidthBitrate(modifiedLocalStats.bandwidth);
+
+            if (modifiedLocalConnectionStrength === 'good' && modifiedLocalConnectionBitrate > 2000) {
+                // Enables the hd video alert only if connection strength is "good"
+                // and bitrate > 2000kbps
+                if (navigator.product !== 'ReactNative') {
+                    window.APP.store.dispatch(setHdVideoAlertEnabled(true));
+                }
+            }
 
             if (localConnectionStrength !== modifiedLocalConnectionStrength) {
                 localConnectionStrength = modifiedLocalConnectionStrength;
@@ -204,6 +214,10 @@ const statsEmitter = {
 
     _getConnectionQuality(connectionQuality: number): Object {
         return CONNECTION_QUALITY_STRENGTH.find(x => connectionQuality >= x.connectionQuality) || {};
+    },
+
+    _getBandWidthBitrate(bandwidth: Object): number {
+        return bandwidth.download + bandwidth.upload;
     }
 };
 

--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -159,9 +159,9 @@ const statsEmitter = {
                 .strength;
             const modifiedLocalConnectionBitrate = this._getBandWidthBitrate(modifiedLocalStats.bandwidth);
 
-            if (modifiedLocalConnectionStrength === 'good' && modifiedLocalConnectionBitrate > 2000) {
+            if (modifiedLocalConnectionStrength === 'good' && modifiedLocalConnectionBitrate > 2500) {
                 // Enables the hd video alert only if connection strength is "good"
-                // and bitrate > 2000kbps
+                // and bitrate > 2500kbps
                 if (navigator.product !== 'ReactNative') {
                     window.APP.store.dispatch(setHdVideoAlertEnabled(true));
                 }

--- a/react/features/notifications/actionTypes.js
+++ b/react/features/notifications/actionTypes.js
@@ -45,3 +45,14 @@ export const SHOW_NOTIFICATION = 'SHOW_NOTIFICATION';
  * }
  */
 export const SET_NOTIFICATIONS_ENABLED = 'SET_NOTIFICATIONS_ENABLED';
+
+/**
+ * The type of (redux) action which signals that hd video alert should be
+ * displayed.
+ *
+ * {
+ *     type: SET_HD_VIDEO_ALERT_ENABLED,
+ *     hdAlertEnabled: Boolean
+ * }
+ */
+export const SET_HD_VIDEO_ALERT_ENABLED = 'SET_HD_VIDEO_ALERT_ENABLED';

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -6,6 +6,7 @@ import type { Dispatch } from 'redux';
 import {
     CLEAR_NOTIFICATIONS,
     HIDE_NOTIFICATION,
+    SET_HD_VIDEO_ALERT_ENABLED,
     SET_NOTIFICATIONS_ENABLED,
     SHOW_NOTIFICATION
 } from './actionTypes';
@@ -173,4 +174,20 @@ export function showParticipantJoinedNotification(displayName: string) {
     joinedParticipantsNames.push(displayName);
 
     return (dispatch: Dispatch<any>) => _throttledNotifyParticipantConnected(dispatch);
+}
+
+/**
+ * Enable/disable the hd video alert.
+ *
+ * @param {boolean} hdAlertEnabled - Whether or not the alert should display.
+ * @returns {{
+ *     type: SET_HD_VIDEO_ALERT_ENABLED,
+ *     enabled: boolean
+ * }}
+ */
+export function setHdVideoAlertEnabled(hdAlertEnabled: boolean) {
+    return {
+        type: SET_HD_VIDEO_ALERT_ENABLED,
+        hdAlertEnabled
+    };
 }

--- a/react/features/notifications/components/web/HdVideoAlert.js
+++ b/react/features/notifications/components/web/HdVideoAlert.js
@@ -1,0 +1,100 @@
+// @flow
+
+import Button from '@atlaskit/button';
+import Flag from '@atlaskit/flag';
+import EditorInfoIcon from '@atlaskit/icon/glyph/editor/info';
+import { colors } from '@atlaskit/theme';
+import React, { useCallback, useState } from 'react';
+import type { Dispatch } from 'redux';
+
+import { setAudioOnly } from '../../../base/audio-only';
+import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
+import { setPreferredVideoQuality } from '../../../video-quality';
+import { VIDEO_QUALITY_LEVELS } from '../../../video-quality/constants';
+
+type Props = {
+    audioOnly: boolean,
+    dispatch: Dispatch<any>,
+    hdAlertEnabled: boolean
+}
+
+const HD_VIDEO_QUALITY = VIDEO_QUALITY_LEVELS.HIGH;
+const ICON_COLOR = colors.N0;
+
+const uid = window.Date.now();
+const appearance = 'normal';
+
+/**
+ * HdVideoAlert component.
+ *
+ * @returns {React$Element<any>}
+ */
+function HdVideoAlert({ audioOnly, hdAlertEnabled, dispatch }: Props) {
+    const [ visible, setVisible ] = useState(true);
+
+    const _setPreferredVideoQuality = qualityLevel => {
+        dispatch(setPreferredVideoQuality(qualityLevel));
+        if (audioOnly) {
+            dispatch(setAudioOnly(false));
+        }
+    };
+
+    const _onDismissed = useCallback(() => {
+        setVisible(false);
+    });
+
+    const _onClick = useCallback(() => {
+        _setPreferredVideoQuality(HD_VIDEO_QUALITY);
+        _onDismissed();
+    }, []);
+
+    if (!visible || !hdAlertEnabled) {
+        return null;
+    }
+
+    const button = (<Button
+        className = 'button'
+        onClick = { _onClick } >
+        {'Improve my video quality'}
+    </Button>);
+
+    const icon = (<EditorInfoIcon
+        label = { appearance }
+        secondaryColor = { ICON_COLOR }
+        size = { 'medium' } />);
+
+    return (<div className = 'hd-video-alert'>
+        <div className = 'hd-video-alert-container'>
+            <Flag
+                appearance = { appearance }
+                description = { button }
+                icon = { icon }
+                id = { uid }
+                isDismissAllowed = { true }
+                onDismissed = { _onDismissed }
+                testId = { uid }
+                title = { 'Load HD for better video quality ?' } />
+        </div>
+    </div>);
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated props for the
+ * {@code HdVideoAlert} component.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Props}
+ */
+function _mapStateToProps(state) {
+    const { enabled: audioOnly } = state['features/base/audio-only'];
+    const { hdAlertEnabled } = state['features/notifications'];
+
+    return {
+        audioOnly,
+        hdAlertEnabled
+    };
+}
+
+export default translate(connect(_mapStateToProps)(HdVideoAlert));

--- a/react/features/notifications/reducer.js
+++ b/react/features/notifications/reducer.js
@@ -6,7 +6,8 @@ import {
     CLEAR_NOTIFICATIONS,
     HIDE_NOTIFICATION,
     SET_NOTIFICATIONS_ENABLED,
-    SHOW_NOTIFICATION
+    SHOW_NOTIFICATION,
+    SET_HD_VIDEO_ALERT_ENABLED
 } from './actionTypes';
 import { NOTIFICATION_TYPE_PRIORITIES } from './constants';
 
@@ -17,6 +18,7 @@ import { NOTIFICATION_TYPE_PRIORITIES } from './constants';
  */
 const DEFAULT_STATE = {
     enabled: true,
+    hdAlertEnabled: false,
     notifications: []
 };
 
@@ -59,6 +61,12 @@ ReducerRegistry.register('features/notifications',
                         timeout: action.timeout,
                         uid: action.uid
                     })
+            };
+
+        case SET_HD_VIDEO_ALERT_ENABLED:
+            return {
+                ...state,
+                hdAlertEnabled: action.hdAlertEnabled
             };
         }
 

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -27,7 +27,7 @@ import {
     IconShareVideo
 } from '../../../base/icons';
 import {
-    getLocalParticipant,
+    getLocalParticipant, getLocalParticipantType,
     getParticipants,
     participantUpdated
 } from '../../../base/participants';
@@ -192,7 +192,12 @@ type Props = {
     /**
      * Invoked to obtain translated strings.
      */
-    t: Function
+    t: Function,
+
+    /**
+     * Whether or not the local participant is a practitioner.
+     */
+    _isStaffMember: boolean
 };
 
 /**
@@ -994,6 +999,7 @@ class Toolbox extends Component<Props, State> {
             _fullScreen,
             _screensharing,
             _sharingVideo,
+            _isStaffMember,
             t
         } = this.props;
 
@@ -1387,6 +1393,12 @@ class Toolbox extends Component<Props, State> {
      * @returns {boolean} True if the button should be displayed.
      */
     _shouldShowButton(buttonName) {
+        if (buttonName === 'videoquality'){
+
+            // Only allows practitioner to change the video quality
+            return this.props._visibleButtons.has(buttonName) && this.props._isStaffMember;
+        }
+
         return this.props._visibleButtons.has(buttonName);
     }
 }
@@ -1458,7 +1470,8 @@ function _mapStateToProps(state) {
             || sharedVideoStatus === 'start'
             || sharedVideoStatus === 'pause',
         _visible: isToolboxVisible(state),
-        _visibleButtons: equals(visibleButtons, buttons) ? visibleButtons : buttons
+        _visibleButtons: equals(visibleButtons, buttons) ? visibleButtons : buttons,
+        _isStaffMember: getLocalParticipantType(state) === 'StaffMember'
     };
 }
 


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-263/telehealth-hd-video-quality-alert)
- [Slack](https://janeapp.slack.com/archives/CTQRM510Q/p1614973707006800)

Since we want to prompt practitioners to enable the HD video beta feature in Jitsi only if they have a good connection. This PR updates the HD video loading flow as below:

![Screen Shot 2021-03-05 at 11 38 30 AM](https://user-images.githubusercontent.com/24568041/113944368-45292380-97b9-11eb-829b-7c3b13b7c917.png)

- Adds an HD video alert component.
- Adds a new HD video constrain setting to keep the HD video full screen since we've added padding to the SD video.
- Limit the video quality to HD(360) when initiating the call.
- Detects the actual connection quality strength in `_onStatsUpdated` listener and shows the `HD video quality alert` only if the practitioner has a "good" connection (connection quality strength > 30, bandwidth bitrate > 2500kps).
- Only allows the practitioner to control the resolution/video quality. 
- Hides the video quality control option for patients.

### General PR Class
👁 = UX / UI improvement
🌟 = New Feature (Adds Functionality) 

### Release Note

### Dependencies / ENV
N/A

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes
Loom Demo Video:
https://www.loom.com/share/2f9f771db8e947df9ef03f73b68e55e3

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
Please make sure the `Telehealth Selectable HD quality` beta flag is enabled > Create an online appointment > join the call > wait until the `Load HD for better video quality?` alert pops up. (if the connection is "good" & the bandwidth > 2000) > click on the `Improve my video quality` button > the video feed should change to HD(720) at full screen.

### Fixed / Expected Behaviour
Loom Demo Video:
https://www.loom.com/share/2f9f771db8e947df9ef03f73b68e55e3

Hd video quality alert component:
<img src="https://user-images.githubusercontent.com/24568041/114129257-17c0a080-98b3-11eb-8b8a-c7eaad1f9f1a.png" width=300>

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
