### PR TITLE
[SCH-322] Update the "authentication failed" error notification in jitsi

### DIFF
--- a/lang/main-enGB.json
+++ b/lang/main-enGB.json
@@ -260,7 +260,7 @@
         "Submit": "Submit",
         "thankYou": "Thank you for using {{appName}}!",
         "token": "token",
-        "tokenAuthFailed": "Sorry, you're not allowed to join this call.",
+        "tokenAuthFailed": "Please try accessing your session again and reach out to the clinic for help.",
         "tokenAuthFailedTitle": "Authentication failed",
         "transcribing": "Transcribing",
         "unlockRoom": "Remove meeting password",

--- a/lang/main-id.json
+++ b/lang/main-id.json
@@ -273,7 +273,7 @@
         "Submit": "Submit",
         "thankYou": "Thank you for using {{appName}}!",
         "token": "token",
-        "tokenAuthFailed": "Sorry, you're not allowed to join this call.",
+        "tokenAuthFailed": "Please try accessing your session again and reach out to the clinic for help.",
         "tokenAuthFailedTitle": "Authentication failed",
         "transcribing": "Transcribing",
         "unlockRoom": "Remove meeting $t(lockRoomPassword)",

--- a/lang/main.json
+++ b/lang/main.json
@@ -295,7 +295,7 @@
         "Submit": "Submit",
         "thankYou": "Thank you for using {{appName}}!",
         "token": "token",
-        "tokenAuthFailed": "Sorry, you're not allowed to join this call.",
+        "tokenAuthFailed": "Please try accessing your session again and reach out to the clinic for help.",
         "tokenAuthFailedTitle": "Authentication failed",
         "transcribing": "Transcribing",
         "unlockRoom": "Remove meeting $t(lockRoomPassword)",

--- a/react/features/notifications/components/web/Notification.js
+++ b/react/features/notifications/components/web/Notification.js
@@ -110,7 +110,7 @@ class Notification extends AbstractNotification<Props> {
      * @private
      * @returns {Object[]}
      */
-    _mapAppearanceToButtons(hideErrorSupportLink) {
+    _mapAppearanceToButtons(hideErrorSupportLink = true) {
         switch (this.props.appearance) {
         case NOTIFICATION_TYPE.ERROR: {
             const buttons = [


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-322/update-the-authentication-failed-error-modal-in-jitsi)

### Issue: 
We noticed that the contact support button in the "authentication failed" error notification modal redirects users to jitsi community forum which is not ideal. 

### Solution: 
After discussing with Julia & Ramineh we decided to remove the contact support button from the error notification and update the original message copy to `Please try accessing your session again and reach out to the clinic for help. `

This PR:
- Remove the "contact button" from the notification component by setting the `hideErrorSupportLink` param to true.
- Update the `tokenAuthFailed` message 

### General PR Class
👁 = UX / UI improvement

### Release Note
Updated the "authentication failed" error notification in jitsi.

### Dependencies / ENV
N/A

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Very low risk

### Demo Notes
https://www.loom.com/share/500b4fa9a8f843709ad25e03bb05f3c8

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce

1. Use an expired video chat [URL](https://videochat-jwt.jane.qa/4db438d2?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZXh0Ijp7InVzZXIiOnsiaWQiOiIxLTEwMSIsIm5hbWUiOiJEZW1vIE93bmVyIiwiZW1haWwiOiJkZW1vLm93bmVyQGphbmUuY2xpbmljIiwicGFydGljaXBhbnRfdHlwZSI6IlBhdGllbnQiLCJwYXJ0aWNpcGFudF9pZCI6MTAxfSwidmlkZW9fY2hhdF9zZXNzaW9uX2lkIjoxMDEsImxlYXZlX3VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMC8vdmlkZW9fY2hhdF9zZXNzaW9ucy8xMDEvcGFydGljaXBhbnRfbGVmdCIsInVwZGF0ZV9wYXJ0aWNpcGFudF9zdGF0dXNfdXJsIjpudWxsLCJwcmFjdGl0aW9uZXJfbmFtZSI6Ik1heWEgTG9wZXotQ2hhcG1hbiIsInRyZWF0bWVudCI6Ik9ubGluZSBWaWRlbyBTZXNzaW9uIiwicm9vbV9zdGF0dXNfdXJsIjpudWxsLCJzdXJ2ZXlfdXJsIjoiaHR0cDovL2xvY2FsaG9zdDozMDAwLy92aWRlb19jaGF0X3Nlc3Npb25zLzRkYjQzOGQyL3N1cnZleT9wYXJ0aWNpcGFudF9pZD0xMDEmcGFydGljaXBhbnRfdHlwZT1QYXRpZW50IiwibGVhdmVfd2FpdGluZ19hcmVhX3VybCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzAwMC8vYWNjb3VudCIsInN0YXJ0X2F0IjoiMjAyMS0wMi0yNVQxMDoxNTowMC0wODowMCIsImVuZF9hdCI6IjIwMjEtMDItMjVUMTE6MTU6MDAtMDg6MDAiLCJ3YWl0aW5nX2FyZWFfZW5hYmxlZCI6ZmFsc2UsImhkX2VuYWJsZWQiOnRydWV9LCJhdWQiOiJqYW5lLWNsaWVudCIsImlzcyI6ImphbmVhcHAiLCJzdWIiOiJ2aWRlb2NoYXQtand0LmphbmUucWEiLCJyb29tIjoiNGRiNDM4ZDIiLCJleHAiOjE2MTQyOTQ5MDAsIm1vZGVyYXRvciI6ZmFsc2V9.0Ivd4STy2aUHSTEBLhfJ4xJ1B-qn-xZrQL7lgyRRmWU) to launch the web app. 
2. You will see the "authentication failed" error notification.

### Fixed / Expected Behaviour
![image](https://user-images.githubusercontent.com/24568041/120021956-962aec00-bfa0-11eb-8639-01f21a112e4e.png)

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/24568041/120022000-a3e07180-bfa0-11eb-871f-92e9afd81214.png)

### After
![image](https://user-images.githubusercontent.com/24568041/120021956-962aec00-bfa0-11eb-8639-01f21a112e4e.png)