### PR TITLE
[SCH-340] Video chat web app sends "left waiting room" signal twice to Jane when user hang up the call.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -43,7 +43,7 @@ import {
     onStartMutedPolicyChanged,
     p2pStatusChanged,
     sendLocalParticipant,
-    setDesktopSharingEnabled, isJaneTestCall
+    setDesktopSharingEnabled
 } from './react/features/base/conference';
 import {
     checkAndNotifyForNewDevice,
@@ -119,7 +119,7 @@ import {
     isJaneWaitingAreaPageEnabled,
     isJaneWaitingAreaPageVisible,
     replaceJaneWaitingAreaAudioTrack,
-    replaceJaneWaitingAreaVideoTrack, updateParticipantReadyStatus
+    replaceJaneWaitingAreaVideoTrack
 } from './react/features/jane-waiting-area';
 import { showNotification } from './react/features/notifications';
 import { mediaPermissionPromptVisibilityChanged } from './react/features/overlay';
@@ -2816,11 +2816,6 @@ export default {
 
         APP.UI.removeAllListeners();
         APP.remoteControl.removeAllListeners();
-
-        if (!isJaneTestCall(APP.store.getState())
-            && isJaneWaitingAreaPageEnabled(APP.store.getState())) {
-            updateParticipantReadyStatus('left');
-        }
 
         let requestFeedbackPromise;
 

--- a/react/features/jane-waiting-area/components/SocketConnection.web.js
+++ b/react/features/jane-waiting-area/components/SocketConnection.web.js
@@ -52,9 +52,14 @@ class SocketConnection extends Component<Props> {
             sendMessageToIosApp({ message: 'webview page is ready' });
         } else {
             updateParticipantReadyStatus('waiting');
-            window.onunload = window.onbeforeunload = function() {
+
+            // When the user closes the window or leaves the waiting area or quits the browser,
+            // We send a "left" signal here to Jane
+            const beforeunloadHanlder = () => {
                 updateParticipantReadyStatus('left');
             };
+
+            window.addEventListener('beforeunload', beforeunloadHanlder);
         }
         this._connectSocket();
     }


### PR DESCRIPTION
## Description
- [Linear](https://linear.app/jane/issue/SCH-340/video-chat-app-sends-left-waiting-room-signal-twice-to-jane-when-users)

### Issue: 
The video chat web app sends "left waiting room" signal twice to the `/video_chat_sessions/update_participant_status` endpoint when the user hangs up the call. 

Solution:
- Only send the "left" signal to Jane when the browser window is unloading since the hangup function would also close the browser window.
- Remove the redundant "left waiting room" POST action from the `hangup` function.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Just 

### Demo Notes


## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Enabled the `waiting area` beta feature.
2. Create an online appointment
3. Join the call
4. Click on the `Hangup` Button.
5. Go to amplitude, On the user lookup page  select `Jane dev environment project
6. Search the user activity log with the conference name.
![image](https://user-images.githubusercontent.com/24568041/121223875-d6aa2580-c83c-11eb-873a-e7e9c465cd3f.png)
7. In the log, After the `toolbar.button.hangup.clicked' event, there should be only one `waiting.area.participant.status.changed.left' event.

### Fixed / Expected Behaviour
When users hang up the call or close the browser window, the web app should send the "left" signal to Jane only once.

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/24568041/121126782-95365d80-c7dd-11eb-8fa5-24941914d7b7.png)

### After
![image](https://user-images.githubusercontent.com/24568041/121126959-dfb7da00-c7dd-11eb-90a9-07014c13fe75.png)
