### PR TITLE
[SCH-340] Video chat web app sends "left waiting room" signal twice to Jane when user hangs up the call

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,9 @@ window.APP = {
         'index.loaded': window.indexLoadedTime
     },
 
+    waitingArea: {
+        status: null
+    },
     keyboardshortcut,
     remoteControl,
     translation,

--- a/conference.js
+++ b/conference.js
@@ -43,7 +43,7 @@ import {
     onStartMutedPolicyChanged,
     p2pStatusChanged,
     sendLocalParticipant,
-    setDesktopSharingEnabled, isJaneTestCall
+    setDesktopSharingEnabled
 } from './react/features/base/conference';
 import {
     checkAndNotifyForNewDevice,
@@ -119,7 +119,7 @@ import {
     isJaneWaitingAreaPageEnabled,
     isJaneWaitingAreaPageVisible,
     replaceJaneWaitingAreaAudioTrack,
-    replaceJaneWaitingAreaVideoTrack, updateParticipantReadyStatus
+    replaceJaneWaitingAreaVideoTrack
 } from './react/features/jane-waiting-area';
 import { showNotification } from './react/features/notifications';
 import { mediaPermissionPromptVisibilityChanged } from './react/features/overlay';
@@ -2817,11 +2817,6 @@ export default {
         APP.UI.removeAllListeners();
         APP.remoteControl.removeAllListeners();
 
-        if (!isJaneTestCall(APP.store.getState())
-            && isJaneWaitingAreaPageEnabled(APP.store.getState())) {
-            updateParticipantReadyStatus('left');
-        }
-
         let requestFeedbackPromise;
 
         if (requestFeedback) {
@@ -2854,7 +2849,6 @@ export default {
                 APP.API.notifyReadyToClose();
             }
             APP.store.dispatch(maybeRedirectToWelcomePage(values[0]));
-            window.close();
         });
     },
 

--- a/conference.js
+++ b/conference.js
@@ -16,7 +16,7 @@ import {
     createStartSilentEvent,
     createScreenSharingEvent,
     createTrackMutedEvent,
-    sendAnalytics
+    sendAnalytics, createWaitingAreaParticipantStatusChangedEvent
 } from './react/features/analytics';
 import {
     maybeRedirectToWelcomePage,
@@ -119,7 +119,7 @@ import {
     isJaneWaitingAreaPageEnabled,
     isJaneWaitingAreaPageVisible,
     replaceJaneWaitingAreaAudioTrack,
-    replaceJaneWaitingAreaVideoTrack
+    replaceJaneWaitingAreaVideoTrack, updateParticipantReadyStatus
 } from './react/features/jane-waiting-area';
 import { showNotification } from './react/features/notifications';
 import { mediaPermissionPromptVisibilityChanged } from './react/features/overlay';
@@ -2816,6 +2816,12 @@ export default {
 
         APP.UI.removeAllListeners();
         APP.remoteControl.removeAllListeners();
+
+        if (window.APP.waitingArea.status === 'initialized') {
+            window.APP.waitingArea.status = 'left';
+            sendAnalytics(createWaitingAreaParticipantStatusChangedEvent('left'));
+            updateParticipantReadyStatus('left');
+        }
 
         let requestFeedbackPromise;
 

--- a/react/features/always-on-top/HangupButton.js
+++ b/react/features/always-on-top/HangupButton.js
@@ -23,6 +23,5 @@ export default class HangupButton extends AbstractHangupButton<Props, *> {
      */
     _doHangup() {
         api.executeCommand('hangup');
-        window.close();
     }
 }

--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -336,7 +336,12 @@ export function maybeRedirectToWelcomePage(options: Object = {}) {
                 () => {
                     dispatch(redirectWithStoredParams('/'));
                 },
-                options.showThankYou ? 3000 : 500);
+                options.showThankYou ? 3000 : 1500);
         }
+
+        // close window after 1 sec
+        setTimeout(() => {
+            window.close();
+        }, 1000);
     };
 }

--- a/react/features/base/util/helpers.js
+++ b/react/features/base/util/helpers.js
@@ -135,3 +135,18 @@ export function reportError(e: Object, msg: string = '') {
     console.error(msg, e);
     window.onerror && window.onerror(msg, null, null, null, e);
 }
+
+/**
+ * A synchronous function that guarantees to execute the code in
+ * the window.beforeunload & window.unload callbacks.
+ * Https://stackoverflow.com/a/42914045.
+ *
+ * @param {num} delay - Milliseconds.
+ * @returns {void}
+ */
+export function sleep(delay: number) {
+    const start = new Date().getTime();
+
+    // eslint-disable-next-line no-empty
+    while (new Date().getTime() < start + delay) { }
+}

--- a/react/features/jane-waiting-area/components/SocketConnection.web.js
+++ b/react/features/jane-waiting-area/components/SocketConnection.web.js
@@ -8,6 +8,7 @@ import { createWaitingAreaParticipantStatusChangedEvent, sendAnalytics } from '.
 import { getLocalParticipantInfoFromJwt, getLocalParticipantType } from '../../base/participants/functions';
 import { connect } from '../../base/redux';
 import { playSound as playSoundAction } from '../../base/sounds';
+import { sleep } from '../../base/util/helpers';
 import {
     setJaneWaitingAreaAuthState as setJaneWaitingAreaAuthStateAction,
     updateRemoteParticipantsStatuses as updateRemoteParticipantsStatusesAction,
@@ -61,8 +62,11 @@ class SocketConnection extends Component<Props> {
             const unloadHandler = () => {
                 if (window.APP.waitingArea.status === 'initialized') {
                     window.APP.waitingArea.status = 'left';
-                    sendAnalytics(createWaitingAreaParticipantStatusChangedEvent('left'));
                     updateParticipantReadyStatus('left');
+                    sendAnalytics(createWaitingAreaParticipantStatusChangedEvent('left'));
+
+                    // sleep here to ensure the above code can be executed when the browser window is closed.
+                    sleep(2000);
                 }
             };
 

--- a/react/features/jane-waiting-area/components/dialogs/JaneDialog.js
+++ b/react/features/jane-waiting-area/components/dialogs/JaneDialog.js
@@ -167,7 +167,9 @@ class JaneDialog extends Component<Props> {
         const { leave_waiting_area_url } = jwtPayload && jwtPayload.context;
 
         openURLInBrowser(leave_waiting_area_url);
-        updateParticipantReadyStatus('left');
+        setTimeout(() => {
+            window.close();
+        }, 1000);
     }
 
     render() {

--- a/react/features/toolbox/components/JaneHangupButton.js
+++ b/react/features/toolbox/components/JaneHangupButton.js
@@ -6,7 +6,6 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
-import { maybeRedirectToWelcomePage } from '../../app/actions';
 import { disconnect } from '../../base/connection';
 import { translate } from '../../base/i18n';
 import { IconHangup } from '../../base/icons';
@@ -33,7 +32,6 @@ class JaneHangupButton extends Component<Props> {
     _hangup = _.once(props => {
         window.APP.API.notifyReadyToClose();
         sendAnalytics(createToolbarEvent('hangup'));
-        props.dispatch(maybeRedirectToWelcomePage());
         props.dispatch(disconnect(false));
     })
 


### PR DESCRIPTION
## Description
- [Linear](https://linear.app/jane/issue/SCH-340/video-chat-app-sends-left-waiting-room-signal-twice-to-jane-when-users)

### Issue: 
The web app sends the "left waiting room" signal multiple times (twice) to the `/video_chat_sessions/update_participant_status` endpoint when a user hangs up the call. 

### Cause:
We want the web app to send the "left" waiting room signal to Jane after a user clicks the `hangup` button or closes the browser window directly. Although the `hangup` handler function will also execute the `window.close()` to close the browser window and this might trigger the `window.beforeunload` & `window.unload` callbacks. However, I noticed that sometimes those callbacks are not guaranteed to be executed. So I have to place the sending `left` signal action in those callbacks and the `hangup` function to ensure Jane can receive the signal and this results in sometimes the app repeatedly firing the request in the callbacks and the hangup function.

### Solution:
In this PR:
- Use the `window.APP.waitingArea.status` global variable as a flag to indicate the status of the waiting area component.
- Check the `window.APP.waitingArea.status` flag before sending the "left" signal, only allow to send if the waiting room status is `initialized` in order to prevent firing the request repeatedly.
- Rewrite the waiting area `UpdateParticipantStatus` function for better error handling.
- Remove unused code.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low risk

### Demo Notes
https://www.loom.com/share/b8e55ad51b5e4fd68519c8757dc14281

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Enabled the `waiting area` beta feature.
2. Create an online appointment
3. Join the call
4. Click on the `Hangup` Button.
5. Go to datadog, please use this [Link](https://app.datadoghq.com/logs/livetail?agg_m=count&agg_q=&agg_t=count&cols=host%2Cservice%2C%40params.info.status%2C%40network.client.ip&from_ts=0&index=&live=true&messageDisplay=inline&query=%40controller%3Avideo_chat_sessions+%40action%3Aupdate_participant_status+%40http.host%3As14.jane.qa&sort_m=&sort_t=&stream_sort=desc&to_ts=-1&top_n=&top_o=&viz=stream) to monitor the `update_participant_status` endpoint in real-time.(if testing on S14 sandbox)
6. There should be only one POST request with 'left' params after clicking the `Hangup` button

Please also ensure the `waiting area` feature works properly.

### Fixed / Expected Behaviour
When users hang up the call or close the browser window, the web app should send the "left" signal to Jane only once.

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
on Datadog:
![ae6dae83-04dd-4c5c-b56a-26664a83cd17](https://user-images.githubusercontent.com/24568041/121419976-704b0300-c921-11eb-81d7-3915a0fc5cfe.png)


### After
on Datadog:
![image](https://user-images.githubusercontent.com/24568041/121419894-54476180-c921-11eb-8e87-84e55f6db3bd.png)

