### PR TITLE
Docker: Inject bugsnag api key from env before compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM node:latest as builder
 
 RUN mkdir /app
 
+ARG BUGSNAG_API_KEY
+
 ADD . /app
 RUN \
   cd /app \
+  && sed -i'' "/const BUGSNAG_API_KEY/s/''/'$BUGSNAG_API_KEY'/" bugsnag.js \
   && npm install \
   && make \
   && make source-package


### PR DESCRIPTION
The key will be provided via the build environment. 

https://github.com/janeapp/terraform-prod/pull/317