### PR TITLE
[SCH-388][iOS] Remove Begin Button from Patient Waiting Room

### DIFF
--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -42,7 +42,8 @@ type DialogBoxProps = {
     setJaneWaitingAreaAuthStateAction: Function,
     locationURL: string,
     remoteParticipantsStatuses: Array<Object>,
-    authState: string
+    authState: string,
+    localParticipantCanJoin: boolean
 };
 
 type SocketWebViewProps = {
@@ -110,6 +111,16 @@ class DialogBox extends Component<DialogBoxProps> {
                 createWaitingAreaPageEvent('webview.error', {
                     error
                 }));
+            this._joinConference();
+        }
+    }
+
+    componentDidUpdate(prevProps: DialogBoxProps): * {
+        const { localParticipantCanJoin, participantType } = this.props;
+
+        if (prevProps.localParticipantCanJoin !== localParticipantCanJoin
+            && participantType === 'Patient'
+            && localParticipantCanJoin) {
             this._joinConference();
         }
     }
@@ -238,10 +249,9 @@ class DialogBox extends Component<DialogBoxProps> {
             participantType,
             jwtPayload,
             locationURL,
-            remoteParticipantsStatuses,
-            authState
+            authState,
+            localParticipantCanJoin
         } = this.props;
-        const localParticipantCanJoin = checkLocalParticipantCanJoin(remoteParticipantsStatuses, participantType);
 
         return (<View style = { styles.janeWaitingAreaContainer }>
             <View style = { styles.janeWaitingAreaDialogBoxWrapper }>
@@ -288,13 +298,13 @@ class DialogBox extends Component<DialogBoxProps> {
                     </View>
                 </View>
                 <View style = { styles.actionButtonWrapper }>
-                    { authState !== 'failed'
-                    && <ActionButton
-                        containerStyle = { styles.joinButtonContainer }
-                        disabled = { !localParticipantCanJoin }
-                        onPress = { this._joinConference }
-                        title = { this._getBtnText() }
-                        titleStyle = { styles.joinButtonText } /> }
+                    { authState !== 'failed' && participantType === 'StaffMember'
+                     && <ActionButton
+                         containerStyle = { styles.joinButtonContainer }
+                         disabled = { !localParticipantCanJoin }
+                         onPress = { this._joinConference }
+                         title = { this._getBtnText() }
+                         titleStyle = { styles.joinButtonText } /> }
                     {
                         authState === 'failed'
                         && <ActionButton
@@ -321,6 +331,7 @@ function mapStateToProps(state): Object {
     const participantType = getLocalParticipantType(state);
     const { locationURL } = state['features/base/connection'];
     const { remoteParticipantsStatuses, authState } = state['features/jane-waiting-area'];
+    const localParticipantCanJoin = checkLocalParticipantCanJoin(remoteParticipantsStatuses, participantType);
 
     return {
         jwt,
@@ -329,7 +340,8 @@ function mapStateToProps(state): Object {
         participant,
         locationURL,
         remoteParticipantsStatuses,
-        authState
+        authState,
+        localParticipantCanJoin
     };
 }
 

--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -121,7 +121,10 @@ class DialogBox extends Component<DialogBoxProps> {
         if (prevProps.localParticipantCanJoin !== localParticipantCanJoin
             && participantType === 'Patient'
             && localParticipantCanJoin) {
-            this._joinConference();
+            // set a 1 sec delay here to ensure that the practitioner can join the call first.
+            setTimeout(() => {
+                this._joinConference();
+            }, 1000);
         }
     }
 

--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -297,23 +297,33 @@ class DialogBox extends Component<DialogBoxProps> {
                         </View>
                     </View>
                 </View>
-                <View style = { styles.actionButtonWrapper }>
-                    { authState !== 'failed' && participantType === 'StaffMember'
-                     && <ActionButton
-                         containerStyle = { styles.joinButtonContainer }
-                         disabled = { !localParticipantCanJoin }
-                         onPress = { this._joinConference }
-                         title = { this._getBtnText() }
-                         titleStyle = { styles.joinButtonText } /> }
-                    {
-                        authState === 'failed'
+                {
+                    participantType === 'StaffMember' && <View style = { styles.actionButtonWrapper }>
+                        {
+                            authState !== 'failed'
+                        && <ActionButton
+                            containerStyle = { styles.joinButtonContainer }
+                            disabled = { !localParticipantCanJoin }
+                            onPress = { this._joinConference }
+                            title = { this._getBtnText() }
+                            titleStyle = { styles.joinButtonText } />
+                        }
+                        {
+                            authState === 'failed'
                         && <ActionButton
                             onPress = { this._return }
-                            title = {
-                                participantType === 'StaffMember'
-                                    ? 'Return to my Schedule' : 'Return to my account' } />
-                    }
-                </View>
+                            title = { 'Return to my Schedule' } />
+                        }
+                    </View>
+                }
+                {
+                    participantType === 'Patient' && authState === 'failed'
+                    && <View style = { styles.actionButtonWrapper }>
+                        <ActionButton
+                            onPress = { this._return }
+                            title = { 'Return to my account' } />
+                    </View>
+                }
             </View>
             <SocketWebView
                 locationURL = { locationURL }
@@ -365,8 +375,6 @@ const DialogTitleHeader = (props: DialogTitleProps) => {
         } else {
             header = 'Waiting for your client...';
         }
-    } else if (localParticipantCanJoin) {
-        header = 'Your practitioner is ready to begin the session.';
     } else {
         header = 'Your practitioner will let you into the session when ready...';
     }
@@ -376,17 +384,33 @@ const DialogTitleHeader = (props: DialogTitleProps) => {
 };
 
 const DialogTitleMsg = (props: DialogTitleProps) => {
-    const { participantType, authState, localParticipantCanJoin } = props;
-    let message;
+    const { authState, localParticipantCanJoin, participantType } = props;
+    const isStaffMember = participantType === 'StaffMember';
 
-    if (!localParticipantCanJoin) {
-        message = 'Test your audio and video while you wait.';
-    } else if (participantType === 'StaffMember') {
-        message = 'When you are ready to begin, click on button below to admit your client into the video session.';
-    } else {
-        message = '';
+    if (authState === 'failed') {
+        return null;
     }
 
-    return (<Text
-        style = { styles.titleMsg }>{ authState === 'failed' ? '' : message }</Text>);
+    if (localParticipantCanJoin && isStaffMember) {
+        return (<Text style = { styles.titleMsg }>
+            When you are ready to begin, click on button below to admit your client into the video session.
+        </Text>);
+    }
+
+    return <>
+        <Text
+            style = { styles.titleMsg }>
+            Please keep your app open to stay on the call.
+        </Text>
+        <Text
+            style = { styles.titleMsg }>
+            You may test your audio and video while you wait.
+        </Text>
+        {
+            !isStaffMember && <Text
+                style = { styles.titleMsg }>
+                Your call will automatically begin momentarily.
+            </Text>
+        }
+    </>;
 };


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-388/remove-begin-button-from-patient-waiting-room)

- Remove the Begin button from the Patient's side of the Waiting Room & update the Modal UI.
- Once the practitioner allows the patient in by clicking the `Admit client` button, the patient in the waiting room will join the call directly.

### Demo Video:
https://www.loom.com/share/53a4c538b0e44550bef36fb6042098dc

### General PR Class
👁 = UX / UI improvement

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [x] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
> Describe what areas of Jane are touched by the change in this PR, and what it would look like if something were to go wrong, and how much damage could be done. Keep your neighborhood deployer in mind when filling in this section, it will help identify errant PRs more quickly during deploy.

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Please ensure that the `waiting_area' beta flag is enabled.
2. Start the online appointment as a patient.
3. If the practitioner allows the patient into the call, the patient will no longer see the `start' button on the waiting room page.
4. Once the practitioner has allowed the patient access by clicking the `admit client' button, the patient in the waiting room will join the call directly.

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After