### PR TITLE
[SCH-388][Web app] Remove Begin Button from Patient Waiting Room 

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -590,7 +590,9 @@
         "waitClient": "Waiting for your client...",
         "patientIsReady": "Your client is ready to begin the session.",
         "waitPractitioner": "Your practitioner will let you into the session when ready...",
-        "testYourDevice": "Please keep your app or browser window open to stay on the call. You may test your audio and video while you wait.",
+        "keepOpen": "Please keep your app or browser window open to stay on the call.",
+        "youMayTest": "You may test your audio and video while you wait.",
+        "callWillBegin": "Your call will automatically begin momentarily.",
         "authenticationExpired": "Your appointment booking has expired"
     },
     "raisedHand": "Would like to speak",

--- a/react/features/jane-waiting-area/components/JaneWaitingArea.js
+++ b/react/features/jane-waiting-area/components/JaneWaitingArea.js
@@ -41,7 +41,7 @@ class JaneWaitingArea extends Component<Props> {
                     isMobile && <Watermarks />
                 }
                 <Preview name = { name } />
-                <Modal />
+                <Modal isMobile = { isMobile } />
                 <div className = 'jane-waiting-area-preview-btn-container settings-button-container'>
                     <AudioSettingsButton visible = { true } />
                     <JaneHangupButton visible = { true } />

--- a/react/features/jane-waiting-area/components/modal/Modal.js
+++ b/react/features/jane-waiting-area/components/modal/Modal.js
@@ -26,14 +26,16 @@ type Props = {
     participantType: string,
     participant: Object,
     authState: string,
-    localParticipantCanJoin: boolean
+    localParticipantCanJoin: boolean,
+    isMobile: boolean
 };
 
 type DialogTitleProps = {
     t: Function,
     participantType: string,
     localParticipantCanJoin: boolean,
-    authState: string
+    authState: string,
+    isMobile: boolean
 }
 
 function DialogTitleComp(props: DialogTitleProps) {
@@ -67,7 +69,7 @@ function DialogTitleMsgComp(props: DialogTitleProps) {
             title = props.t('janeWaitingArea.whenYouAreReady');
         }
     } else {
-        title = props.t('janeWaitingArea.testYourDevice');
+        title = `${props.t('janeWaitingArea.keepOpen')} ${props.t('janeWaitingArea.youMayTest')}`;
     }
 
     if (props.authState === 'failed') {
@@ -76,6 +78,14 @@ function DialogTitleMsgComp(props: DialogTitleProps) {
 
     if (title === '') {
         return null;
+    }
+
+    if (props.participantType === 'Patient' && props.isMobile) {
+        return <>
+            <div className = 'jane-waiting-area-modal-title-msg'>{props.t('janeWaitingArea.keepOpen')}</div>
+            <div className = 'jane-waiting-area-modal-title-msg'>{props.t('janeWaitingArea.youMayTest')}</div>
+            <div className = 'jane-waiting-area-modal-title-msg'>{props.t('janeWaitingArea.callWillBegin')}</div>
+        </>;
     }
 
     return <div className = 'jane-waiting-area-modal-title-msg'>{title}</div>;
@@ -100,6 +110,16 @@ class Modal extends Component<Props> {
 
         updateParticipantReadyStatus('joined');
         joinConference();
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        const { localParticipantCanJoin, participantType } = this.props;
+
+        if (localParticipantCanJoin !== prevProps.localParticipantCanJoin
+            && localParticipantCanJoin
+            && participantType === 'Patient') {
+            this._joinConference();
+        }
     }
 
     _getStartDate() {
@@ -174,7 +194,8 @@ class Modal extends Component<Props> {
             participantType,
             jwtPayload,
             localParticipantCanJoin,
-            authState
+            authState,
+            isMobile
         } = this.props;
         const { _joinConference } = this;
 
@@ -193,6 +214,7 @@ class Modal extends Component<Props> {
                         participantType = { participantType } />
                     <DialogTitleMsg
                         authState = { authState }
+                        isMobile = { isMobile }
                         localParticipantCanJoin = { localParticipantCanJoin }
                         participantType = { participantType } />
                     <div className = 'jane-waiting-area-modal-detail'>
@@ -219,24 +241,24 @@ class Modal extends Component<Props> {
                 </div>
             </div>
             {
-                <div
+                authState !== 'failed' && participantType === 'StaffMember' && <div
                     className = 'jane-waiting-area-preview-join-btn-container'>
-                    {
-                        authState !== 'failed' && <ActionButton
-                            disabled = { !localParticipantCanJoin }
-
-                            onClick = { _joinConference }
-                            type = 'primary'>
-                            {this._getBtnText()}
-                        </ActionButton>
-                    }
-                    {
-                        authState === 'failed' && <ActionButton
-                            onClick = { this._onFailed }
-                            type = 'primary'>
-                            {this._getBtnText()}
-                        </ActionButton>
-                    }
+                    <ActionButton
+                        disabled = { !localParticipantCanJoin }
+                        onClick = { _joinConference }
+                        type = 'primary'>
+                        {this._getBtnText()}
+                    </ActionButton>
+                </div>
+            }
+            {
+                authState === 'failed' && <div
+                    className = 'jane-waiting-area-preview-join-btn-container'>
+                    <ActionButton
+                        onClick = { this._onFailed }
+                        type = 'primary'>
+                        {this._getBtnText()}
+                    </ActionButton>
                 </div>
             }
         </div>);

--- a/react/features/jane-waiting-area/components/modal/Modal.js
+++ b/react/features/jane-waiting-area/components/modal/Modal.js
@@ -70,6 +70,9 @@ function DialogTitleMsgComp(props: DialogTitleProps) {
         }
     } else {
         title = `${props.t('janeWaitingArea.keepOpen')} ${props.t('janeWaitingArea.youMayTest')}`;
+        if (props.participantType === 'Patient') {
+            title = `${title} ${props.t('janeWaitingArea.callWillBegin')}`;
+        }
     }
 
     if (props.authState === 'failed') {


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-388/remove-begin-button-from-patient-waiting-room)

- A follow-up PR for SCH-373
- Remove the Begin button from the Patient's side of the Waiting Room & update the Modal UI for android devices.
- Once the practitioner allows the patient in by clicking the `Admit client` button, the patient in the waiting room will join the call directly.

### Demo Video:
https://www.loom.com/share/eb572193c9524defbf53183906bb0974

### General PR Class
👁 = UX / UI improvement

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [x] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Please ensure that the `waiting_area' beta flag is enabled.
2. Start the online appointment as a patient.
3. If the practitioner allows the patient into the call, the patient will no longer see the `start' button on the waiting room page.
4. Once the practitioner has allowed the patient access by clicking the `admit client' button, the patient in the waiting room will join the call directly.

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After