### PR TITLE
[SCH-393][Web app] Display Treatment length not scheduled length in Appointment Modal

### DIFF
--- a/react/features/jane-waiting-area/components/dialogs/JaneDialog.js
+++ b/react/features/jane-waiting-area/components/dialogs/JaneDialog.js
@@ -137,17 +137,30 @@ class JaneDialog extends Component<Props> {
 
     _getDuration() {
         const { jwtPayload, t } = this.props;
-        const startAt = _.get(jwtPayload, 'context.start_at') ?? '';
-        const endAt = _.get(jwtPayload, 'context.end_at') ?? '';
+        const startAt = _.get(jwtPayload, 'context.start_at');
+        const endAt = _.get(jwtPayload, 'context.end_at');
+        const treatmentDuration = _.get(jwtPayload, 'context.treatment_duration');
+        let duration;
 
-        if (!startAt || !endAt) {
+        if (treatmentDuration) {
+            duration = Number(treatmentDuration) / 60;
+        }
+
+        if (startAt && endAt && !treatmentDuration) {
+            const ms = getLocalizedDateFormatter(endAt)
+                .valueOf() - getLocalizedDateFormatter(startAt)
+                .valueOf();
+
+            duration = moment.duration(ms).asMinutes();
+        }
+
+        if (!duration) {
             return null;
         }
-        const duration = getLocalizedDateFormatter(endAt).valueOf() - getLocalizedDateFormatter(startAt).valueOf();
 
         return (<p>
             {
-                t('janeWaitingArea.minutes', { duration: moment.duration(duration).asMinutes() })
+                t('janeWaitingArea.minutes', { duration })
             }
         </p>);
     }


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-393/display-treatment-length-not-scheduled-length-in-appointment-moda)

- A follow-up PR for LANG-19
- In the waiting room modal, use `treament_duration` from jwt payload in priority to calculate the treatment length.

### Demo Video:
[Demo Video](https://www.loom.com/share/a8590f4a215042b0a0ae969178d301b1)

### General PR Class
👁 = UX / UI improvement

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Please ensure that the "waiting_area" beta flag is enabled.
2. Book an appointment online.
3. Change the appointment length in the schedule.
4. Launch the video chat app and the waiting room modal will show the treatment length instead of the scheduled length.

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After
