### PR TITLE
Log real client IPs in nginx container

### DIFF
--- a/docker-configs/nginx/nginx.conf
+++ b/docker-configs/nginx/nginx.conf
@@ -37,6 +37,10 @@ http {
   # Logging Settings
   ##
 
+  log_format main '$http_host $remote_addr - $remote_user [$time_local] "$request" '
+      '$status $body_bytes_sent $request_time "$http_referer" '
+      '"$http_user_agent" "$http_x_forwarded_for" "$msec"';
+
   access_log /dev/stdout;
   error_log /dev/stderr;
 
@@ -55,6 +59,9 @@ http {
   # gzip_buffers 16 8k;
   # gzip_http_version 1.1;
   # gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+  set_real_ip_from 10.0.0.0/8;
+  real_ip_header X-Forwarded-For;
 
   ##
   # Virtual Host Configs

--- a/docker-configs/nginx/nginx.conf
+++ b/docker-configs/nginx/nginx.conf
@@ -41,7 +41,7 @@ http {
       '$status $body_bytes_sent $request_time "$http_referer" '
       '"$http_user_agent" "$http_x_forwarded_for" "$msec"';
 
-  access_log /dev/stdout;
+  access_log /dev/stdout main;
   error_log /dev/stderr;
 
   ##


### PR DESCRIPTION
These changes let us log real client IP addresses in datadog, instead of the intermediary Amazon Load Balancer IP.