### PR TITLE
[Fix] strange contrasting brightness shades in the video

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -134,7 +134,7 @@ function computeCameraVideoSize( // eslint-disable-line max-params
             width = maxWidth - padding;
         }
 
-        return [ width, height ];
+        return [ Math.round(width), Math.round(height) ];
     }
     default:
         return [ videoWidth, videoHeight ];


### PR DESCRIPTION
## Description
- [Slack](https://janeapp.slack.com/archives/C0109LT2A3S/p1622233211044700)
- [Helpscout](https://secure.helpscout.net/conversation/1525390447/527754?folderId=4067769)

Issue: a clinic is having issues with video quality: there is a strange line just off the center of the screen and leaves to contrasting brightness shades.
<img width="300" alt="IMG1" src="https://user-images.githubusercontent.com/24568041/125982377-6918ca17-8698-4ecc-83a6-45bd70c5c3bd.png">

Solution:
Round the width & height of the video when calculating the video container dimensions, 

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note
Fixed the strange contrasting brightness shades issue

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Should be very low, just a fix to round the width & height of the video.

### Demo Notes


## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [x] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
Since we couldn't reproduce the issue, Please do a smoke test.
the change has been deployed to `videochat-jwt.jane.qa` & it can be tested in any sandbox.

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After