### PR TITLE
[SCH-460] Telehealth video is zooming in and out during call (web app)

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -92,7 +92,7 @@ function computeCameraVideoSize( // eslint-disable-line max-params
         // Avoid NaN values caused by devision by 0.
         return [ 0, 0 ];
     }
-    const conferenceHasStarted = getRemoteTracks(APP.store.getState()['features/base/tracks']).length > 0;
+    const tracks = APP.store.getState()['features/base/tracks'];
     const aspectRatio = videoWidth / videoHeight;
 
     switch (videoLayoutFit) {
@@ -102,7 +102,7 @@ function computeCameraVideoSize( // eslint-disable-line max-params
         return [ videoSpaceWidth, videoSpaceWidth / aspectRatio ];
     case 'both': {
         const videoSpaceRatio = videoSpaceWidth / videoSpaceHeight;
-        const maxZoomCoefficient = getMaxZoomCoefficient(videoHeight, conferenceHasStarted);
+        const maxZoomCoefficient = getMaxZoomCoefficient(videoHeight, aspectRatio, tracks);
 
         if (videoSpaceRatio === aspectRatio) {
             return [ videoSpaceWidth, videoSpaceHeight ];
@@ -145,12 +145,16 @@ function computeCameraVideoSize( // eslint-disable-line max-params
  * Returns a number of the max zoom coefficient, return 1 if the video stream is
  * standard definition or low definition or if the user is in the pre-conference stage
  *
- * @param videoHeight the original video height
- * @param conferenceHasStarted attribute to tell if the conference has started
+ * @param {number} videoHeight the original video height
+ * @param {number} aspectRatio - Aspect ratio of the video.
+ * @param {Track[]} tracks - List of all tracks.
  * @return number
  */
-function getMaxZoomCoefficient(videoHeight, conferenceHasStarted) {
-    if (videoHeight <= SD_VIDEO_HEIGHT || !conferenceHasStarted) {
+function getMaxZoomCoefficient(videoHeight, aspectRatio, tracks) {
+    const conferenceHasStarted = getRemoteTracks(tracks).length > 0;
+    const isMobileRemoteTrack = aspectRatio < 1 && conferenceHasStarted;
+
+    if ((videoHeight <= SD_VIDEO_HEIGHT && !isMobileRemoteTrack) || !conferenceHasStarted) {
         return 1;
     }
 


### PR DESCRIPTION
## Description
[Linear](https://linear.app/jane/issue/SCH-460/telehealth-video-is-zooming-in-and-out-during-call)
[Slack](https://janeapp.slack.com/archives/C0109LT2A3S/p1629992033003600)

Although we are not able to reproduce this bug, I believe it's an edge case that occurs when one of the participants is using chrome on an android tablet (portrait mode) and encounters a bad network connection. the video height could be automatically reduced below 360 by Jitsi, causes the `getMaxZoomCoefficient` function to return different values during the change, resulting in a zoom-in/zoom-out effect on another participant's video screen (using a desktop).

Solution:
- Do not apply paddings & only return the default `MAXIMUM_ZOOMING_COEFFICIENT` value for the remote mobile video tracks.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)


### Dependencies / ENV
> Describe any dependencies or ENV variables that are required for this change. Notify the team, if they have to update their environment.

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
very low, just stop adding paddings to the video tracks sent by mobile devices.

### Demo Notes
Can't demo it since we can't reproduce the issue.

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
The build has been deployed to `videochat-chrisw.jane.qa` jitsi sandbox and S8 is pointing to it.

### Fixed / Expected Behaviour
We can not reproduce the issue so please:
- Create an online appointment on S8 sandbox, Launch the session on a browser & on an ios device.
- Smoke test the video chat web app
- Smoke test the video chat ios app (TestFlight version)
- if possible, smoke test the web app on an android tablet/phone.

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After