### PR TITLE
[SCH-525][Web app] Analytics events to track waiting room socket message and admit button actions

### DIFF
--- a/react/features/analytics/AnalyticsEvents.js
+++ b/react/features/analytics/AnalyticsEvents.js
@@ -839,3 +839,22 @@ export function createWaitingAreaParticipantStatusChangedEvent(status) {
         }
     };
 }
+
+// eslint-disable-next-line require-jsdoc
+export function createWaitingAreaSocketEvent(action, event) {
+    return {
+        action,
+        actionSubject: 'waiting.area.socket',
+        attributes: {
+            event
+        }
+    };
+}
+
+// eslint-disable-next-line require-jsdoc
+export function createWaitingAreaModalEvent(action) {
+    return {
+        action,
+        actionSubject: 'waiting.area.modal'
+    };
+}

--- a/react/features/jane-waiting-area/components/SocketConnection.web.js
+++ b/react/features/jane-waiting-area/components/SocketConnection.web.js
@@ -4,7 +4,11 @@
 import { Component } from 'react';
 
 import { Socket } from '../../../../service/Websocket/socket';
-import { createWaitingAreaParticipantStatusChangedEvent, sendAnalytics } from '../../analytics';
+import {
+    createWaitingAreaParticipantStatusChangedEvent,
+    createWaitingAreaSocketEvent,
+    sendAnalytics
+} from '../../analytics';
 import { getLocalParticipantInfoFromJwt, getLocalParticipantType } from '../../base/participants/functions';
 import { connect } from '../../base/redux';
 import { playSound as playSoundAction } from '../../base/sounds';
@@ -106,8 +110,9 @@ class SocketConnection extends Component<Props> {
         const { participantType, updateRemoteParticipantsStatusesFromSocket } = this.props;
 
         if (event.info && event.info.status && event.participant_type && (event.participant_type !== participantType)) {
-            this._playSound(event);
             updateRemoteParticipantsStatusesFromSocket(event);
+            sendAnalytics(createWaitingAreaSocketEvent('message.received', event));
+            this._playSound(event);
         }
     }
 


### PR DESCRIPTION
## Description

- [Linear](https://linear.app/jane/issue/SCH-525/analytics-events-to-track-waiting-rooms-socket-message-and-admit)

- use `createWaitingAreaSocketEvent` & `createWaitingAreaModalEvent` events to track socket messages sent from Jane & the admit button actions in the waiting room modal

![image](https://user-images.githubusercontent.com/24568041/134556766-a7e5e6a7-bad4-4045-a600-19bf21582c7e.png)


### General PR Class
👁 = UX / UI improvement

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Very low,  just send analytics events to datadog 

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. Enable waiting room & create an online appointment (on s8 sandbox)
2. Join an online appointment (It is better to join from the practitioner side first)
3. Go to this [datadog link](https://app.datadoghq.com/logs?query=%40params.id%3A%2A%20%40rails.resource%3Avideo_chat_sessions%23event%20%40http.status_code%3A200%20%40params.name%3Awaiting.area%2A&cols=%40params.id%2C%40http.useragent_details.browser.family%2C%40params.participant_type%2C%40params.participant_id%2C%40http.useragent_details.os.family%2C%40params.name&index=&integration_id=&integration_short_name=&messageDisplay=inline&saved_view=481094&stream_sort=desc&viz=stream&from_ts=1631809791919&to_ts=1632414591919&live=true)
4. Click on "Views" -> select "Online appointment activity logs" -> replace the @params.id:* with @params.id:"your room name"
5. Datadog should show the "waiting.area.modal.admit.button" & "waiting.area.socket.message.received" events as below

![image](https://user-images.githubusercontent.com/24568041/134556807-2802e246-27aa-4c98-9bb5-425bf556039e.png)

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After
