### PR TITLE
Increase the z-index of the waiting room modal

### DIFF
--- a/css/_jane-waiting-area.scss
+++ b/css/_jane-waiting-area.scss
@@ -22,7 +22,7 @@
         left: 0;
         top: 0;
         height: 100%;
-        z-index: 1;
+        z-index: 99999;
     }
 
     &-modal-dialog {
@@ -174,6 +174,7 @@
             left: 0;
             right: 0;
             top: unset;
+            z-index: 99999;
         }
 
         &-modal-dialog {


### PR DESCRIPTION
## Description

- At a particular window size, it is possible that the user will not be able to click the "admit" button due to the hidden component's occlusion.

![image (1)](https://user-images.githubusercontent.com/24568041/134590020-bc83fe2c-2634-4de2-9041-801514db5c4c.png)

Solution: increase the z-index of the waiting room modal

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note

### Dependencies / ENV

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
almost zero just a css change.

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. create an online appointment (on s8 sandbox)
2. launch the video chat web app
3. on the practitioner side, shrink the window to 1456 X 580
4. when the admit button turns blue, user can still click the button

### Fixed / Expected Behaviour


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After