### PR TITLE
[Fix] video is zooming in and out on firefox

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -5,11 +5,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { browser } from '../../../react/features/base/lib-jitsi-meet';
-import { getRemoteTracks } from '../../../react/features/base/tracks';
+import { getRemoteTracks, isHdQualityEnabled } from '../../../react/features/base/tracks';
 import { ORIENTATION, LargeVideoBackground } from '../../../react/features/large-video';
 import { LAYOUTS, getCurrentLayout } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
-import { VIDEO_QUALITY_LEVELS } from '../../../react/features/video-quality/constants';
 import UIEvents from '../../../service/UI/UIEvents';
 import UIUtil from '../util/UIUtil';
 
@@ -20,7 +19,6 @@ import LargeContainer from './LargeContainer';
 export const VIDEO_CONTAINER_TYPE = 'camera';
 
 const FADE_DURATION_MS = 300;
-const SD_VIDEO_HEIGHT = VIDEO_QUALITY_LEVELS.STANDARD;
 const SD_VIDEO_CONTAINER_PADDING_PERCENTAGE = 0.1;
 const SD_VIDEO_CONTAINER_PADDING_BREAKPOINT = 768;
 
@@ -154,7 +152,17 @@ function getMaxZoomCoefficient(videoHeight, aspectRatio, tracks) {
     const conferenceHasStarted = getRemoteTracks(tracks).length > 0;
     const isMobileRemoteTrack = aspectRatio < 1 && conferenceHasStarted;
 
-    if ((videoHeight <= SD_VIDEO_HEIGHT && !isMobileRemoteTrack) || !conferenceHasStarted) {
+    // Because of browser compatibility issues, we are unable to add SD video constraints to Firefox.
+    // we need to determine here if HD quality is enabled in Jane
+    // and add paddings if the hd quality is disabled.
+    // TODO: If we decide to enable hd beta feature in the future,
+    //  we may need an xmpp listener/flag to check if the
+    //  practitioner side allows the patient to switch to hd,
+    //  since this feature is controlled by the practitioner side
+    const isHdVideoQualityFeatureEnable = isHdQualityEnabled(APP.store.getState());
+
+    if ((!isHdVideoQualityFeatureEnable && !isMobileRemoteTrack)
+        || !conferenceHasStarted) {
         return 1;
     }
 


### PR DESCRIPTION
## Description
[Linear](https://linear.app/jane/issue/SCH-626/telehealth-video-is-zooming-in-and-out-during-call)

- Fix an issue that video is zooming in and out on firefox by applying padding to the video on all types of browsers if HD beta feature is disabled.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Release Note
Ivan fixed a Telehealth issue where the video was zooming in and out on Firefox.

### Dependencies / ENV
> Describe any dependencies or ENV variables that are required for this change. Notify the team, if they have to update their environment.

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Should be low

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

- [x] I clearly explained the WHY behind the work, in the Description above

#### Design
- [x] I added instructions for how to test, in the QA section below
- [x] I added specs for changes, or determined that none were required
- [ ] I demoed this to the appropriate person
- [x] I considered both mobile & desktop views, or that wasn't relevant

#### Code
- [x] I committed code with informative git messages
- [x] I wrote readable code, or added comments if it was complex
- [x] I performed a self-review of my own code
- [x] I rebased my branch on the latest `master`

## QA and Smoke Testing
### Steps to Reproduce
1. create an online appointment
2. open the video chat app on firefox
3. after joining the session from the waiting room, Jitsi should add paddings to the video in the large video layout.

### Fixed / Expected Behaviour


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After