### PR TITLE
Enable the nginx stub_status endpoint for datadog monitoring

### DIFF
--- a/docker-configs/nginx/nginx.conf
+++ b/docker-configs/nginx/nginx.conf
@@ -63,6 +63,22 @@ http {
   set_real_ip_from 10.0.0.0/8;
   real_ip_header X-Forwarded-For;
 
+  # status endpoint
+  server {
+    listen 81;
+    server_name localhost;
+    access_log off;
+
+    location /nginx_status {
+      stub_status on;
+      allow 127.0.0.1;
+      allow 10.0.0.0/8;
+      allow 172.16.0.0/12;
+      allow 192.168.0.0/16;
+      deny all;
+    }
+  }
+  
   ##
   # Virtual Host Configs
   ##


### PR DESCRIPTION
This enables nginx stats, which Datadog will be able to collect.
