### PR TITLE
Disable e2eping

### DIFF
--- a/docker-configs/templates/config.js.j2
+++ b/docker-configs/templates/config.js.j2
@@ -42,6 +42,9 @@ var config = {
       }
     }
   },
+  e2eping: {
+      pingInterval: -1
+  },
   prejoinPageEnabled: false,
   analytics: {
     googleAnalyticsTrackingId: '{{ GOOGLE_ANALYTICS_ID }}',


### PR DESCRIPTION
This disables the e2eping module (it show's the RTT in the info popup for each user.

There is some evidence that it negatively impacts performance, especially as you start having larger conferences.