### PR TITLE
Set "real ip" in nginx on requests from any private IP range

### DIFF
--- a/docker-configs/nginx/nginx.conf
+++ b/docker-configs/nginx/nginx.conf
@@ -61,6 +61,8 @@ http {
   # gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
   set_real_ip_from 10.0.0.0/8;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
   real_ip_header X-Forwarded-For;
 
   # status endpoint


### PR DESCRIPTION
This is because load balancer requests can come from either a 10.*
range or a 172.* range.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
