### PR TITLE
Fix connection promise is undefined (follow-up)

### DIFF
--- a/react/features/jane-waiting-area/actions.js
+++ b/react/features/jane-waiting-area/actions.js
@@ -59,7 +59,6 @@ export function initJaneWaitingArea(tracks: Object[], connection: Object[], erro
         const videoTrack = tracks.find(t => t.isVideoTrack());
 
         dispatch(setJaneWaitingAreaDeviceErrors(errors));
-        dispatch(addConnectionToJaneWaitingArea(connection));
 
         if (audioTrack) {
             dispatch(addJaneWaitingAreaAudioTrack(audioTrack));
@@ -77,6 +76,10 @@ export function initJaneWaitingArea(tracks: Object[], connection: Object[], erro
         } else {
             dispatch(setJaneWaitingAreaVideoDisabled(true));
         }
+
+        setTimeout(() => {
+            dispatch(addConnectionToJaneWaitingArea(connection));
+        });
     };
 }
 

--- a/react/features/jane-waiting-area/components/modal/Modal.js
+++ b/react/features/jane-waiting-area/components/modal/Modal.js
@@ -134,7 +134,9 @@ class Modal extends Component<Props> {
         if (localParticipantCanJoin !== prevProps.localParticipantCanJoin
             && localParticipantCanJoin) {
             if (participantType === 'Patient') {
-                this._joinConference();
+                setTimeout(() => {
+                    this._joinConference();
+                }, 2000);
             }
             if (participantType === 'StaffMember') {
                 sendAnalytics(createWaitingAreaModalEvent('admit.button.enabled'));


### PR DESCRIPTION
## Description
A follow-up PR of https://github.com/janeapp/video-chat/pull/96

[Linear](https://linear.app/jane/issue/SCH-689/fix-connection-promise-is-undefined-in-online-appointments)
Issue: The "addConnectionToJaneWaitingArea" action is fired before  "add audio/video track" actions, causing Jitsi(on some older hardware) to send empty video/audio tracks after joining the session from waiting room.

[Slack thread1](https://janeapp.slack.com/archives/C0109LT2A3S/p1635176087013300)
[Slack thread2](https://janeapp.slack.com/archives/C0109LT2A3S/p1635284270021700?thread_ts=1635284158.021500&cid=C0109LT2A3S)

Solution:
- make sure the "addConnectionToJaneWaitingArea"  action is triggered after the audio/video track has been initialized

### General PR Class
🐛 = Bug Fix (Fixes an Issue)


### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes
Can not be demoed.

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
### Steps to Reproduce
As we are unable to replicate the issue
Please smoke test the waiting room feature and ensure both patient & practitioner can join the session from iOS app / Web app
