### PR TITLE
Change docker builder stage from node:latest to node:lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest as builder
+FROM node:lts as builder
 
 RUN mkdir /app
 


### PR DESCRIPTION
Looks like node:latest changed from node 16 to 17 yesterday, and this causes build errors.

LTS keeps us on node16.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
