### PR TITLE
[SCH-736][iOS] Online Appointments and Activity report is not recording in the Online Appointments Report

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -400,16 +400,16 @@ export function conferenceWillLeave(conference: Object) {
     return (dispatch: Function, getState: Function) => {
         const state = getState();
         const { jwt } = state['features/base/jwt'];
-        const { conferenceStartedTime } = getState()['features/base/conference'];
+        const { start } = getState()['features/base/conference'];
 
-        if (jwt && conferenceStartedTime) {
+        if (jwt && start) {
             const jwtPayload = jwtDecode(jwt);
             const leaveUrl = jwtPayload.context.leave_url || null;
             const surveyUrl = jwtPayload.context.survey_url || null;
             const obj = {
                 jwt,
                 // eslint-disable-next-line camelcase
-                started_at: conferenceStartedTime.toISOString()
+                started_at: start
             };
             const data = new Blob([ JSON.stringify(obj, null, 2) ], { type: 'text/plain; charset=UTF-8' });
 


### PR DESCRIPTION
## Description
- [Linear](https://linear.app/jane/issue/SCH-736/online-appointments-and-activity-report-is-not-recording-in-the-online)

This PR fixes an issue that the iOS app is not sending the duration of the session to Jane.

- Obtain the correct conference "start" time variable from the "conference" reducer in order to send it to Jane when participants leave the session 

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes
> If you have instructions on how to demo or a video add it here

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
### Steps to Reproduce
1. Install the v1.4.2 Video chat iOS app via TestFlight.
2. Create an online appointment (Can be on any sandbox)
4. Join the session as the practitioner/patient with the v1.4.2 iOS app .
5. Hang up the call

We should be able to see the logs of the session in "Report -> Activity" report and the duration/details in the "Report-> Online appointments"

![image](https://user-images.githubusercontent.com/24568041/140974563-4d02eb2f-43d2-4a89-a484-698218cc7066.png)

![image](https://user-images.githubusercontent.com/24568041/140975808-3f39eded-4577-4a51-9efa-0d63beb1ff7d.png)

#### Since we will be submitting a new build to Apple for this fix, we may need to smoke test the v1.4.2 build to make sure everything is working properly.

### Fixed / Expected Behaviour


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After