### PR TITLE
[SCH-630][Web][iOS] Display the Treatment End Time of the Appointment in Waiting Room Modal 

### DIFF
--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -162,10 +162,16 @@ class DialogBox extends Component<DialogBoxProps> {
     _getStartTimeAndEndTime() {
         const { jwtPayload } = this.props;
         const startAt = _.get(jwtPayload, 'context.start_at') ?? '';
-        const endAt = _.get(jwtPayload, 'context.end_at') ?? '';
+        let endAt = _.get(jwtPayload, 'context.end_at') ?? '';
+        const treatmentDuration = Number(_.get(jwtPayload, 'context.treatment_duration'));
 
         if (!startAt || !endAt) {
             return null;
+        }
+
+        if (treatmentDuration) {
+            endAt = getLocalizedDateFormatter(startAt)
+                .valueOf() + (treatmentDuration * 1000);
         }
 
         return (<Text style = { styles.msgText }>

--- a/react/features/jane-waiting-area/components/web/modal/Modal.js
+++ b/react/features/jane-waiting-area/components/web/modal/Modal.js
@@ -162,10 +162,16 @@ class Modal extends Component<Props> {
     _getStartTimeAndEndTime() {
         const { jwtPayload } = this.props;
         const startAt = _.get(jwtPayload, 'context.start_at') ?? '';
-        const endAt = _.get(jwtPayload, 'context.end_at') ?? '';
+        let endAt = _.get(jwtPayload, 'context.end_at') ?? '';
+        const treatmentDuration = Number(_.get(jwtPayload, 'context.treatment_duration'));
 
         if (!startAt || !endAt) {
             return null;
+        }
+
+        if (treatmentDuration) {
+            endAt = getLocalizedDateFormatter(startAt)
+                .valueOf() + (treatmentDuration * 1000);
         }
 
         return (<p>


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-630/display-the-treatment-start-time-end-time-and-duration-of-the)

This PR includes fixes for iOS app and web app:

- Calculate the end time of the appointment in the waiting room modal by adding the treatment duration to the start time


### General PR Class
🐛 = Bug Fix (Fixes an Issue)


### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low

### Demo Notes
set treatment length to 1 hour & scheduled length to 120 minutes in Jane (for an online only treatment).
![image](https://user-images.githubusercontent.com/24568041/138323382-b9489feb-fc46-4441-b03b-d7b2cc3ee179.png)

the end time of the appt should be "start time + treatment length".
web app:
<img src="https://user-images.githubusercontent.com/24568041/138323519-0d1bd24c-db60-46a0-92da-c6d0e0f34a6a.png" width=300>
ios app:
<img src="https://user-images.githubusercontent.com/24568041/144146352-37b22d45-32b7-4f9e-bdd9-d655c7acb6b7.png" width=300>



## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
1. enable waiting room beta feature
2. go to Settings -> Offering -> Treatments & Classes
3. Edit the online-only treatment
![image](https://user-images.githubusercontent.com/24568041/138324909-8c5dbff4-6226-44fc-ab8a-5d033c788388.png)

4. Change scheduled length to 2 hours
![image](https://user-images.githubusercontent.com/24568041/138323382-b9489feb-fc46-4441-b03b-d7b2cc3ee179.png)
5. Open an online appointment on iOS devices & Desktop browsers.
6. in the waiting room modal, the end time of the appt should be "start time + treatment length(60 minutes)".
Web app:
<img src="https://user-images.githubusercontent.com/24568041/138323519-0d1bd24c-db60-46a0-92da-c6d0e0f34a6a.png" width=300>
iOS app:
<img src="https://user-images.githubusercontent.com/24568041/144146352-37b22d45-32b7-4f9e-bdd9-d655c7acb6b7.png" width=300>

### Steps to Reproduce

