### PR TITLE
[Fix][iOS] Polling fallback for Socket webview page when the page fails to load.

### DIFF
--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -3,7 +3,7 @@
 import jwtDecode from 'jwt-decode';
 import _ from 'lodash';
 import moment from 'moment';
-import React, { Component } from 'react';
+import React, { Component, useCallback, useEffect, useState } from 'react';
 import { Image, Linking, Text, View, Clipboard } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -17,8 +17,9 @@ import {
     setJaneWaitingAreaAuthState,
     updateRemoteParticipantsStatuses
 } from '../../actions';
+import { POLL_INTERVAL, MAX_TIMEOUT_SEC } from '../../constants';
 import {
-    checkLocalParticipantCanJoin,
+    checkLocalParticipantCanJoin, checkRoomStatus, getRemoteParticipantsStatuses,
     updateParticipantReadyStatus
 } from '../../functions';
 
@@ -51,7 +52,9 @@ type DialogBoxProps = {
 type SocketWebViewProps = {
     onError: Function,
     onMessageUpdate: Function,
-    locationURL: string
+    locationURL: string,
+    startPolling: Function,
+    stopPolling: Function
 }
 
 const getWebViewUrl = (locationURL: any) => {
@@ -62,19 +65,65 @@ const getWebViewUrl = (locationURL: any) => {
     return uri;
 };
 
+let webViewTimer;
+
 const SocketWebView = (props: SocketWebViewProps) => {
+    const [ loading, setLoading ] = useState(false);
+    const [ time, setTime ] = useState(0);
+
+    const clearTimer = () => {
+        setTime(0);
+        webViewTimer && clearInterval(webViewTimer);
+        props.stopPolling();
+    };
+
+    useEffect(() => {
+        if (loading) {
+            webViewTimer = setInterval(() => {
+                setTime(prevTime => prevTime + 1);
+            }, 1000);
+        } else {
+            clearTimer();
+        }
+    }, [ loading ]);
+
+    useEffect(() => {
+        if (time === MAX_TIMEOUT_SEC) {
+            clearTimer();
+            props.startPolling();
+        }
+    }, [ time ]);
+
+    useEffect(() => () => {
+        clearTimer();
+    }, []);
+
     const injectedJavascript = `(function() {
           window.postMessage = function(data) {
             window.ReactNativeWebView.postMessage(data);
           };
         })()`;
 
+    const onLoadStart = useCallback(() => {
+        setLoading(true);
+    });
+
+    const onLoadEnd = useCallback(() => {
+        setLoading(false);
+    });
+
     return (<View
         style = { styles.socketView }>
         <WebView
+            allowFileAccessFromFileURLs = { true }
+            allowUniversalAccessFromFileURLs = { true }
             injectedJavaScript = { injectedJavascript }
+            mixedContentMode = { 'always' }
             onError = { props.onError }
+            onLoadEnd = { onLoadEnd }
+            onLoadStart = { onLoadStart }
             onMessage = { props.onMessageUpdate }
+            originWhitelist = { [ '*' ] }
             source = {{ uri: getWebViewUrl(props.locationURL) }}
             startInLoadingState = { false } />
     </View>);
@@ -87,6 +136,9 @@ class DialogBox extends Component<DialogBoxProps> {
     _return: Function;
     _onMessageUpdate: Function;
     _admitClient: Function;
+    _startPolling: Function;
+    _stopPolling: Function;
+    _poller: any
 
     constructor(props) {
         super(props);
@@ -95,6 +147,9 @@ class DialogBox extends Component<DialogBoxProps> {
         this._webviewOnError = this._webviewOnError.bind(this);
         this._return = this._return.bind(this);
         this._onMessageUpdate = this._onMessageUpdate.bind(this);
+        this._startPolling = this._startPolling.bind(this);
+        this._stopPolling = this._stopPolling.bind(this);
+        this._poller = null;
     }
 
     componentDidMount() {
@@ -104,8 +159,42 @@ class DialogBox extends Component<DialogBoxProps> {
         sendAnalytics(
             createWaitingAreaPageEvent('loaded', undefined));
         updateParticipantReadyStatus('waiting', jwt);
+        this.fetchRoomStatus();
     }
 
+    async fetchRoomStatus() {
+        const { jwt, participantType, updateRemoteParticipantsStatusesAction } = this.props;
+
+        try {
+            const response = await checkRoomStatus(jwt);
+            const remoteParticipantsStatuses
+                = getRemoteParticipantsStatuses(response.participant_statuses, participantType);
+
+            updateRemoteParticipantsStatusesAction(remoteParticipantsStatuses);
+        } catch (error) {
+            sendAnalytics(
+                createWaitingAreaPageEvent('fetch.room.status.failed', {
+                    error
+                })
+            );
+
+            // We'll handle the error in the Conference component.
+            this._joinConference();
+        }
+    }
+
+    _startPolling() {
+        sendAnalytics(createWaitingAreaModalEvent('polling.started'));
+        this._poller = setInterval(this.fetchRoomStatus.bind(this), POLL_INTERVAL);
+    }
+
+    _stopPolling() {
+        if (this._poller) {
+            clearInterval(this._poller);
+            sendAnalytics(createWaitingAreaModalEvent('polling.stopped'));
+            this._poller = null;
+        }
+    }
 
     _webviewOnError(error) {
         try {
@@ -139,6 +228,7 @@ class DialogBox extends Component<DialogBoxProps> {
         const { updateRemoteParticipantsStatusesAction } = this.props;
 
         updateRemoteParticipantsStatusesAction([]);
+        this._stopPolling();
     }
 
     _joinConference() {
@@ -355,7 +445,9 @@ class DialogBox extends Component<DialogBoxProps> {
             <SocketWebView
                 locationURL = { locationURL }
                 onError = { this._webviewOnError }
-                onMessageUpdate = { this._onMessageUpdate } />
+                onMessageUpdate = { this._onMessageUpdate }
+                startPolling = { this._startPolling }
+                stopPolling = { this._stopPolling } />
         </View>);
 
     }

--- a/react/features/jane-waiting-area/constants.js
+++ b/react/features/jane-waiting-area/constants.js
@@ -2,3 +2,4 @@
 export const POLL_INTERVAL = 5000;
 export const REDIRECT_TO_WELCOME_PAGE_DELAY = 5000;
 export const CLOSE_BROWSER_DELAY = 2000;
+export const MAX_TIMEOUT_SEC = 10;


### PR DESCRIPTION
## Description

### Issue:
We noticed a rare edge case( one [report](https://janeapp.slack.com/archives/C0109LT2A3S/p1634581288216800) from support team so far). A user launched Jane online appointments ios app from the `Apple Mail app` and the socket bridge web view page could not be loaded properly when initializing the waiting room component. As we're not able to reproduce this issue. My guess is that it was probably because the ios system was blocking the page due to some security/privacy reasons and oddly this didn't trigger the `onError` callback of the Webview component as well.

### Solution:
Since the `onError` listener is unable to detect whether the webview page is fully loaded, I decided to use `onLoadEnd` and `onLoadStart` listener to monitor the loading status of the page, if it doesn't finish loading within 10 seconds, waiting room(iOS) will start polling to fetch the latest state of another participant from Jane.

In this PR:
- fallback to polling (fetch the room status every 5 secs) if the socket web view page doesn't finish loading after 10 seconds
- Change the logic of the checkRoomStatus function a bit so that it can be used by both the web app and ios app.
- add  `allowFileAccessFromFileURLs`, `allowUniversalAccessFromFileURLs`, `originWhitelist`  props to the WebView component to prevent the loading failure.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Dependencies / ENV
N/A

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Low, as this “polling fallback” will only be triggered when the socket webview fails to load.

### Demo Notes


## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
### Steps to Reproduce
Since we are unable to reproduce the issue, please smoke test the iOS app(TestFlight v1.5 build 6) with waiting room enabled to ensure everything works properly.

### Fixed / Expected Behaviour
