### PR TITLE
[SCH-849] Some ios users unable to connect to prosody xmpp server

### DIFF
--- a/react/features/jane-waiting-area/components/native/ActionButton.js
+++ b/react/features/jane-waiting-area/components/native/ActionButton.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { Text, TouchableOpacity, ActivityIndicator } from 'react-native';
 
 import styles from './styles';
 
@@ -8,21 +8,22 @@ type Props = {
     onPress: Function,
     title: string,
     disabled?: boolean,
+    loading?: boolean
 };
 
 export const ActionButton = (props: Props): React$Node => {
 
     const containerStyle = props.disabled ? styles.disabledButtonContainer : styles.joinButtonContainer;
     const titleStyle = props.disabled ? styles.disabledButtonText : styles.joinButtonText;
+    const content = props.loading ? (<ActivityIndicator
+        size = 'small' />) : <Text style = { [ styles.actionBtnTitle, titleStyle ] }>{props.title}</Text>;
 
     return (<TouchableOpacity
         disabled = { props.disabled }
         onPress = { props.onPress }
         style = { [ styles.actionButtonContainer, containerStyle ] }>
-        <Text style = { [ styles.actionBtnTitle, titleStyle ] }>
-            {
-                props.title
-            }
-        </Text>
+        {
+            content
+        }
     </TouchableOpacity>);
 };

--- a/react/features/jane-waiting-area/components/native/DialogBox.js
+++ b/react/features/jane-waiting-area/components/native/DialogBox.js
@@ -3,7 +3,7 @@
 import jwtDecode from 'jwt-decode';
 import _ from 'lodash';
 import moment from 'moment';
-import React, { Component } from 'react';
+import React, { Component, useEffect } from 'react';
 import { Image, Linking, Text, View, Clipboard } from 'react-native';
 import { WebView } from 'react-native-webview';
 
@@ -32,6 +32,8 @@ type DialogTitleProps = {
     t: Function
 }
 
+const JOIN_SESSION_DELAY = 2000;
+
 type DialogBoxProps = {
     joinConferenceAction: Function,
     startConferenceAction: Function,
@@ -46,6 +48,10 @@ type DialogBoxProps = {
     authState: string,
     localParticipantCanJoin: boolean,
     t: Function
+};
+
+type DialogBoxState = {
+    connectSocket: boolean,
 };
 
 type SocketWebViewProps = {
@@ -69,6 +75,11 @@ const SocketWebView = (props: SocketWebViewProps) => {
           };
         })()`;
 
+    useEffect(() => () => {
+        sendAnalytics(
+            createWaitingAreaPageEvent('socket.disconnected', undefined));
+    }, []);
+
     return (<View
         style = { styles.socketView }>
         <WebView
@@ -80,7 +91,7 @@ const SocketWebView = (props: SocketWebViewProps) => {
     </View>);
 };
 
-class DialogBox extends Component<DialogBoxProps> {
+class DialogBox extends Component<DialogBoxProps, DialogBoxState> {
 
     _joinConference: Function;
     _webviewOnError: Function;
@@ -93,6 +104,9 @@ class DialogBox extends Component<DialogBoxProps> {
         this._webviewOnError = this._webviewOnError.bind(this);
         this._return = this._return.bind(this);
         this._onMessageUpdate = this._onMessageUpdate.bind(this);
+        this.state = {
+            connectSocket: true
+        };
     }
 
     componentDidMount() {
@@ -123,10 +137,7 @@ class DialogBox extends Component<DialogBoxProps> {
         if (prevProps.localParticipantCanJoin !== localParticipantCanJoin
             && participantType === 'Patient'
             && localParticipantCanJoin) {
-            // set a 1 sec delay here to ensure that the practitioner can join the call first.
-            setTimeout(() => {
-                this._joinConference();
-            }, 1000);
+            this._joinConference();
         }
     }
 
@@ -139,9 +150,15 @@ class DialogBox extends Component<DialogBoxProps> {
     _joinConference() {
         const { startConferenceAction, enableJaneWaitingAreaAction, jwt } = this.props;
 
-        updateParticipantReadyStatus(jwt, 'joined');
-        enableJaneWaitingAreaAction(false);
-        startConferenceAction();
+        this.setState({
+            connectSocket: false
+        });
+
+        setTimeout(() => {
+            updateParticipantReadyStatus(jwt, 'joined');
+            enableJaneWaitingAreaAction(false);
+            startConferenceAction();
+        }, JOIN_SESSION_DELAY);
     }
 
     _getStartDate() {
@@ -267,6 +284,7 @@ class DialogBox extends Component<DialogBoxProps> {
             authState,
             t
         } = this.props;
+        const { connectSocket } = this.state;
 
         return (<View style = { styles.janeWaitingAreaContainer }>
             <View style = { styles.janeWaitingAreaDialogBoxWrapper }>
@@ -320,7 +338,8 @@ class DialogBox extends Component<DialogBoxProps> {
                             authState !== 'failed'
                         && <ActionButton
                             containerStyle = { styles.joinButtonContainer }
-                            disabled = { !localParticipantCanJoin }
+                            disabled = { !localParticipantCanJoin || !connectSocket }
+                            loading = { !connectSocket }
                             onPress = { this._joinConference }
                             title = { this._getBtnText() }
                             titleStyle = { styles.joinButtonText } />
@@ -342,10 +361,12 @@ class DialogBox extends Component<DialogBoxProps> {
                     </View>
                 }
             </View>
-            <SocketWebView
-                locationURL = { locationURL }
-                onError = { this._webviewOnError }
-                onMessageUpdate = { this._onMessageUpdate } />
+            {
+                connectSocket && <SocketWebView
+                    locationURL = { locationURL }
+                    onError = { this._webviewOnError }
+                    onMessageUpdate = { this._onMessageUpdate } />
+            }
         </View>);
 
     }


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-849/some-ios-users-unable-to-connect-to-prosody-xmpp-server)

- Make sure the socket webview is unmounted & force users to wait two seconds before joining the session from waiting room.
- Add loading indicator to admit button.
- Send "disconnected" analytics event to datadog when unmounting webview.

### General PR Class
🐛 = Bug Fix (Fixes an Issue)

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Should be low, a quick fix to ensure the webview is unmounted when user joining the actual session from waiting room.

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
### Steps to Reproduce

Please download the 1.4.3 ios app from TestFlight.
enable the "waiting room" beta feature
Please smoke test the ios build on s18 sandbox & demo-cac1-7.janeapp.com.

### Fixed / Expected Behaviour
Users should be able to join the session & establish the connection after passing through waiting room without issues.

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After