### PR TITLE
[SCH-850] add new universal link domains to the ios app.

### DIFF
--- a/ios/app/app.entitlements
+++ b/ios/app/app.entitlements
@@ -12,6 +12,16 @@
 		<string>applinks:videochat.janeapp.com.au</string>
 		<string>applinks:videochat.janeapp.co.uk</string>
 		<string>applinks:videochat-chrisw.jane.qa</string>
+		<string>applinks:jitsi2.jane.qa</string>
+		<string>applinks:conference-pod-cac1-j1.janeapp.net</string>
+		<string>applinks:conference-pod-usw2-j2.janeapp.net</string>
+		<string>applinks:conference-pod-euw2-j3.janeapp.net</string>
+		<string>applinks:conference-pod-apse2-j4.janeapp.net</string>
+		<string>applinks:video-conference-ca.janeapp.net</string>
+		<string>applinks:video-conference-us.janeapp.net</string>
+		<string>applinks:video-conference-uk.janeapp.net</string>
+		<string>applinks:video-conference-au.janeapp.net</string>
+		<string>applinks:video-conference.jane.qa</string>
 	</array>
 	<key>com.apple.developer.siri</key>
 	<true/>

--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -29,7 +29,7 @@
 
     jitsiMeet.conferenceActivityType = JitsiMeetConferenceActivityType;
     jitsiMeet.customUrlScheme = @"janeoa";
-    jitsiMeet.universalLinkDomains = @[@"videochat-jwt.jane.qa",@"videochat.jane.qa",@"videochat-us.janeapp.com",@"videochat-ca.janeapp.com",@"videochat-ca2.janeapp.com",@"videochat.janeapp.com.au",@"videochat.janeapp.co.uk", @"videochat-chrisw.jane.qa"];
+    jitsiMeet.universalLinkDomains = @[@"videochat-jwt.jane.qa",@"videochat.jane.qa",@"videochat-chrisw.jane.qa",@"videochat-us.janeapp.com",@"videochat-ca.janeapp.com",@"videochat-ca2.janeapp.com",@"videochat.janeapp.com.au",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"jitsi2.jane.qa",@"conference-pod-cac1-j1.janeapp.net",@"conference-pod-usw2-j2.janeapp.net",@"conference-pod-euw2-j3.janeapp.net",@"conference-pod-apse2-j4.janeapp.net",@"video-conference-ca.janeapp.net",@"video-conference-us.janeapp.net",@"video-conference-uk.janeapp.net",@"video-conference-au.janeapp.net",@"video-conference.jane.qa"];
 
     jitsiMeet.defaultConferenceOptions = [JitsiMeetConferenceOptions fromBuilder:^(JitsiMeetConferenceOptionsBuilder *builder) {
         builder.serverURL = [NSURL URLWithString:@"https://videochat.jane.qa"];

--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -29,7 +29,7 @@
 
     jitsiMeet.conferenceActivityType = JitsiMeetConferenceActivityType;
     jitsiMeet.customUrlScheme = @"janeoa";
-    jitsiMeet.universalLinkDomains = @[@"videochat-jwt.jane.qa",@"videochat.jane.qa",@"videochat-chrisw.jane.qa",@"videochat-us.janeapp.com",@"videochat-ca.janeapp.com",@"videochat-ca2.janeapp.com",@"videochat.janeapp.com.au",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"videochat.janeapp.co.uk",@"jitsi2.jane.qa",@"conference-pod-cac1-j1.janeapp.net",@"conference-pod-usw2-j2.janeapp.net",@"conference-pod-euw2-j3.janeapp.net",@"conference-pod-apse2-j4.janeapp.net",@"video-conference-ca.janeapp.net",@"video-conference-us.janeapp.net",@"video-conference-uk.janeapp.net",@"video-conference-au.janeapp.net",@"video-conference.jane.qa"];
+    jitsiMeet.universalLinkDomains = @[@"videochat-jwt.jane.qa",@"videochat.jane.qa",@"videochat-chrisw.jane.qa",@"videochat-us.janeapp.com",@"videochat-ca.janeapp.com",@"videochat-ca2.janeapp.com",@"videochat.janeapp.com.au",@"videochat.janeapp.co.uk",@"jitsi2.jane.qa",@"conference-pod-cac1-j1.janeapp.net",@"conference-pod-usw2-j2.janeapp.net",@"conference-pod-euw2-j3.janeapp.net",@"conference-pod-apse2-j4.janeapp.net",@"video-conference-ca.janeapp.net",@"video-conference-us.janeapp.net",@"video-conference-uk.janeapp.net",@"video-conference-au.janeapp.net",@"video-conference.jane.qa"];
 
     jitsiMeet.defaultConferenceOptions = [JitsiMeetConferenceOptions fromBuilder:^(JitsiMeetConferenceOptionsBuilder *builder) {
         builder.serverURL = [NSURL URLWithString:@"https://videochat.jane.qa"];

--- a/react/features/base/known-domains/reducer.js
+++ b/react/features/base/known-domains/reducer.js
@@ -23,7 +23,18 @@ export const DEFAULT_STATE = [
     'videochat-ca.janeapp.com',
     'videochat-ca2.janeapp.com',
     'videochat.janeapp.com.au',
-    'videochat.janeapp.co.uk'
+    'videochat.janeapp.co.uk',
+    'videochat-chrisw.jane.qa',
+    'jitsi2.jane.qa',
+    'conference-pod-cac1-j1.janeapp.net',
+    'conference-pod-usw2-j2.janeapp.net',
+    'conference-pod-euw2-j3.janeapp.net',
+    'conference-pod-apse2-j4.janeapp.net',
+    'video-conference-ca.janeapp.net',
+    'video-conference-us.janeapp.net',
+    'video-conference-uk.janeapp.net',
+    'video-conference-au.janeapp.net',
+    'video-conference.jane.qa'
 ];
 
 const STORE_NAME = 'features/base/known-domains';

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -40,12 +40,22 @@ const _URI_PATH_PATTERN = '([^?#]*)';
  * "videochat-ca2.janeapp.com",
  * "videochat.janeapp.com.au",
  * "videochat.janeapp.co.uk";
+ * 'videochat-chrisw.jane.qa',
+ * 'jitsi2.jane.qa',
+ * 'conference-pod-cac1-j1.janeapp.net',
+ * 'conference-pod-usw2-j2.janeapp.net',
+ * 'conference-pod-euw2-j3.janeapp.net',
+ * 'conference-pod-apse2-j4.janeapp.net',
+ * 'video-conference-ca.janeapp.net',
+ * 'video-conference-us.janeapp.net',
+ * 'video-conference-uk.janeapp.net',
+ * 'video-conference-au.janeapp.net',
+ * 'video-conference.jane.qa'
  *
  * @private
  * @type {string}
  */
-// eslint-disable-next-line max-len,no-useless-escape
-const _JANE_UNIVERSAL_LINK_DOMAINS = /videochat(?:\-(?:(?:ca2?|us)\.janeapp\.com|jwt|chrisw\.jane\.qa)|\.janeapp\.co(?:m\.au|\.uk))/;
+const _JANE_UNIVERSAL_LINK_DOMAINS = '([a-z0-9]+[.])*(jane|janeapp).(qa|com|com.au|co.uk|net)';
 
 /**
  * The {@link RegExp} pattern of the protocol of a URI.


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-850/add-new-universal-links-to-ios-app)

- add new universal link domains to the ios app.

### General PR Class
👁 = UX / UI improvement

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Should be low, just adding new domains to the ios app

### Demo Notes

## Code Review
Resource: [Dev Team Notion Page](https://www.notion.so/janeapp/Dev-Team-f06c6eb2ccca4066bc63fc1ac1bd2549)
Resource: [Code Review Checklist](https://www.notion.so/janeapp/Code-Review-checklist-2c510c527ac7470c902a5e8f25f9db3c)

## QA and Smoke Testing
### Steps to Reproduce

Please download the 1.5.1(build 2) ios app from TestFlight.
Please make sure the ios app can be launched from
s8, s19, s18, s20 sandboxes.

The following is the relationship between the new jitsi domains and the sandboxes

```
'conference-pod-cac1-j1.janeapp.net' -> s18,
'conference-pod-usw2-j2.janeapp.net'-> s8,
'conference-pod-euw2-j3.janeapp.net',-> s20,
'conference-pod-apse2-j4.janeapp.net-> s19,
```

### Fixed / Expected Behaviour


### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After