### PR TITLE
Change domain name from meet.jitsi to meet.jane [PLA-1374]

### DIFF
--- a/docker-configs/templates/config.js.j2
+++ b/docker-configs/templates/config.js.j2
@@ -1,7 +1,7 @@
 var config = {
   hosts: {
-    domain: 'meet.jitsi',
-    muc: 'muc.meet.jitsi'
+    domain: 'meet.jane',
+    muc: 'muc.meet.jane'
   },
   bosh: '//{{ PUBLIC_URL }}/http-bind',
   websocket: 'wss://{{ PUBLIC_URL }}/xmpp-websocket',


### PR DESCRIPTION
# Description of the changes

Changes the internal domain name from `meet.jitsi` to `meet.jane`

# Why are these changes needed?
 
The domain may be visible in parts of the UI

# Release Instructions

Deploy at the same time as the other updates services (jicofo, prosody, jvb, nginx websocket, nginx app)

https://github.com/janeapp/jitsi-jicofo/pull/7
https://github.com/janeapp/jitsi-jvb/pull/5
https://github.com/janeapp/jitsi-prosody/pull/6
https://github.com/janeapp/jitsi-nginx/pull/7
https://github.com/janeapp/video-chat/pull/115

# Roll back Plan

Revert, make a new build, and deploy it along with reverted builds of the other services

# Associated Ticket

[PLA-1374](https://linear.app/jane/issue/PLA-1374/change-nginx-app-domain-name)

# Risk

Low risk. Could break jitsi, but it's not in production yet.

# QA

Make sure the containers still start and we can open a conference.

