### PR TITLE
[SCH-885] Add minimize events to Datadog to indicate the activity has moved to the background

### DIFF
--- a/react/features/analytics/AnalyticsEvents.js
+++ b/react/features/analytics/AnalyticsEvents.js
@@ -964,3 +964,19 @@ export function createWaitingAreaPageEvent(action, attributes = {}) {
         source: 'waiting.area'
     };
 }
+
+/**
+ * Creates an event which indicates if the app is in the foreground or background.
+ *
+ * @param {string} action - The action that the event represents.
+ * @param {boolean} attributes - Additional attributes to attach to the event.
+ * @returns {Object} The event in a format suitable for sending via
+ * sendAnalytics.
+ */
+export function createAppStateChangedEvent(action, attributes = {}) {
+    return {
+        action,
+        attributes,
+        source: 'app.state.changed'
+    };
+}

--- a/react/features/jane-waiting-area/middleware.js
+++ b/react/features/jane-waiting-area/middleware.js
@@ -1,10 +1,12 @@
 // @flow
 
+import { createAppStateChangedEvent, sendAnalytics } from '../analytics';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../base/app';
 import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../base/media';
 import { MiddlewareRegistry } from '../base/redux';
 import { updateSettings } from '../base/settings';
 import { registerSound, unregisterSound } from '../base/sounds';
+import { APP_STATE_CHANGED } from '../mobile/background/actionTypes';
 
 import {
     JANE_WAITING_AREA_START_CONFERENCE
@@ -65,7 +67,33 @@ MiddlewareRegistry.register(store => next => async action => {
         break;
     }
 
+    case APP_STATE_CHANGED: {
+        return _appStateChanged(store, next, action);
+    }
+
     }
 
     return next(action);
 });
+
+/**
+ * Send analytics event to datadog based on the app state.
+ *
+ * @param {Store} store - The redux store in which the specified {@code action}
+ * is being dispatched.
+ * @param {Dispatch} next - The redux {@code dispatch} function to dispatch the
+ * specified {@code action} to the specified {@code store}.
+ * @param {Action} action - The redux action {@code APP_STATE_CHANGED} which is
+ * being dispatched in the specified {@code store}.
+ * @private
+ * @returns {Object} The value returned by {@code next(action)}.
+ */
+function _appStateChanged(store, next, action) {
+    if (navigator.product === 'ReactNative') {
+        const { appState } = action;
+
+        sendAnalytics(createAppStateChangedEvent(appState));
+    }
+
+    return next(action);
+}


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-885/add-minimize-events-to-datadog-to-indicate-the-activity-has-moved-to)

- Creates an "app.state.changed" event to indicate if the app is in the foreground or background.
- Sends this event to datadog if the "appstate" has changed.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/24568041/153469655-bb67d241-446f-4753-9824-2fb346f4f200.png">
### General PR Class
👁 = UX / UI improvement

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Very low as this analytics event should not affect the waiting room functionality.

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce
Please install the latest testflight build(V1.5.1 build 2) before testing 

1. Have a client join an online appointment call before the practitioner with the iOS app.
2. Move the ios app to the background then move it back to the foreground.
3. Go to datadog logs and filter out the events relevant to the session
4. You can find the "app.state.changed.active","app.state.changed.inactive","app.state.changed.background" events in the logs.

<img width="664" alt="image" src="https://user-images.githubusercontent.com/24568041/153469655-bb67d241-446f-4753-9824-2fb346f4f200.png">

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After