### PR TITLE
[SCH-817] Waiting room brightness has a darkness overlay added to it

### DIFF
--- a/css/_jane-waiting-area.scss
+++ b/css/_jane-waiting-area.scss
@@ -328,23 +328,6 @@
         }
     }
 
-    &-overlay {
-        height: 100%;
-        position: absolute;
-        width: 100%;
-        z-index: 1;
-        background: linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3));
-    }
-
-    &-bottom-overlay {
-        background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.9) 100%);
-        bottom: 0;
-        height: 50%;
-        position: absolute;
-        width: 100%;
-        z-index: 1;
-    }
-
     &-status {
         align-items: center;
         bottom: 0;

--- a/react/features/jane-waiting-area/components/web/preview/Preview.js
+++ b/react/features/jane-waiting-area/components/web/preview/Preview.js
@@ -50,8 +50,6 @@ function Preview(props: Props) {
     if (showCameraPreview && videoTrack) {
         return (
             <div className = 'jane-waiting-area-preview'>
-                <div className = 'jane-waiting-area-preview-overlay' />
-                <div className = 'jane-waiting-area-preview-bottom-overlay' />
                 <Video
                     className = { `jane-waiting-area-preview-video ${screensharing ? '' : 'flipVideoX'} ` }
                     videoTrack = {{ jitsiTrack: videoTrack }} />


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-817/waiting-room-brightness-has-a-darkness-overlay-added-to-it)

- Remove redundant preview overlay elements from the waiting room "Preview" component

### General PR Class
👁 = UX / UI improvement

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Risk is very low as the PR only has a few minor changes on the waiting room preview UI

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce
1. Create an online appointment (on S8 sandbox)
2. Join it first as the practitioner (via web app); notice the brightness
3. Join then with the patient; 
4. The brightness should be the same in the waiting room as well as once in a call 

It would be great if we can smoke test this web app build as well.

### Fixed / Expected Behaviour

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After