### PR TITLE
Use turn servers for jvb connections (tcp only)

### DIFF
--- a/docker-configs/templates/config.js.tmpl
+++ b/docker-configs/templates/config.js.tmpl
@@ -35,6 +35,7 @@ var config = {
     preferH264: false,
     disableH264: true
   },
+  useStunTurn: true,
   resolution: 360,
   maxFps: 15,
   constraints: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Adds `useStunTurn: true` outside of p2p block, so turn servers can also be used for JVB calls.  However, it will not relay UDP connections to the JVB since the JVB can already do that.

For TCP, the JVB is much less efficient than the turn server, so if client's UDP is blocked, they can connect to TURN via TCP and that relays to JVB over UDP.