### PR TITLE
[SCH-968][iOS] Online Appointments on iPad aren't able to be put in landscape mode

### DIFF
--- a/ios/app/src/Info.plist
+++ b/ios/app/src/Info.plist
@@ -90,6 +90,11 @@
 		<string>ProximaNova-Sbold.otf</string>
 		<string>ProximaNova-Thin.otf</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
@@ -108,10 +113,17 @@
 	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
-	<key>UISupportedInterfaceOrientations</key>
+	<key>UISupportedInterfaceOrientations~iphone</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/SCH-968/online-appointments-on-ipad-arent-able-to-be-put-in-landscape-mode)

- Allow rotation(landscape mode) while keeping the app running full-screen on iPad
- Keep "portrait mode only" setting for iPhone

### General PR Class
👁 = UX / UI improvement

### Risk Scorecard
> 1. As the author you should check the boxes that correspond with your PR and then use the following guide to set your risk label:
> * 0 checkboxes => low risk
> * 1-3 checkboxes => medium risk
> * 4+ checkboxes => high risk
> 2. Unless exempt, checked risk factors should be explained comprehensively in the Release Risk Assessment section below
> 3. Medium or higher risk PRs should get more than one code-review approval
>
> NOTE: if you aren't changing any production files, please use the zero risk label

- [ ] requires env configuration to be added in production
- [ ] js package changes<sup>1</sup>
- [ ] more than 200 LOC changed in production files<sup>1</sup>
- [ ] includes a user-facing workflow change to an existing production feature (user muscle memory or pattern recognition will be affected)
- [ ] could prevent access to Jane Video (eg. cors, middleware, changes to auth system)
- [ ] affects a widely used component or piece of code
- [ ] I have a doubt - I want the RMT to review this. If possible, please elaborate your concerns in the risk assessment section.

<sup>1</sup> No need to explain these risk factors below

### Release Risk Assessment
Risk is very low as the PR only has a few info.plist setting changes

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce
Download the v1.5.2 (build 2) test flight app
1. Create an online appointment (on S8 sandbox)
2. Launch the app on iPad: the app can be rotated to landscape mode
3. Launch the app on iPhone: the app should only run under portrait mode.
4. It would be great if we can do a smoke test.

Note: The welcome screen may have some UI errors in landscape mode on ipad, which is expected since we don't initially support landscape mode for all iOS devices.
<img width="841" alt="image" src="https://user-images.githubusercontent.com/24568041/160920425-e0e88e17-d7ab-47e7-b958-73ca32203833.png">


### Fixed / Expected Behaviour
on iPad
![image](https://user-images.githubusercontent.com/24568041/160920266-a9980236-c5b1-47b0-aafb-f37ef7ba477a.png)
on iPhone
<img width="864" alt="image" src="https://user-images.githubusercontent.com/24568041/160920805-fda04311-d8b5-4b70-ba7a-077a77f1af41.png">

### Jane Desktop
> - Should these changes be tested in Jane Desktop? If the PR touches any of the [areas outlined here](https://www.notion.so/janeapp/Jane-Desktop-a10c9c06b180487982a3ef67d6163db9#9ea43281537e458089a87229e7281612), the answer is probably yes. If yes, indicate which areas.
> - How to test [video-chat inside Jane Desktop locally is outlined here](https://github.com/janeapp/jane_electron/blob/master/README.md#testing-video-chat)

### Other Considerations

## Screenshots
### Before
### After
