### PR TITLE
Enable audio level in config.js

### DIFF
--- a/docker-configs/templates/config.js.tmpl
+++ b/docker-configs/templates/config.js.tmpl
@@ -21,7 +21,7 @@ var config = {
   enableRemb: true,
   enableUnifiedOnChrome: true,
   disablePolls: true,
-  disableAudioLevels: true,
+  disableAudioLevels: false,
   disableReactions: true,
   disableRemoteControl: true,
   disableRemoteMute: true,

--- a/react/features/audio-level-indicator/components/AudioLevelIndicator.js
+++ b/react/features/audio-level-indicator/components/AudioLevelIndicator.js
@@ -41,6 +41,10 @@ class AudioLevelIndicator extends Component<Props> {
     render() {
         const { audioLevel: passedAudioLevel } = this.props;
 
+        if (passedAudioLevel) {
+            return null;
+        }
+
         // First make sure we are sensitive enough.
         const audioLevel = typeof passedAudioLevel === 'number' && !isNaN(passedAudioLevel)
             ? Math.min(passedAudioLevel * 1.2, 1) : 0;


### PR DESCRIPTION
- Set `disableAudioLevels` option to false to enable the audio level bar in the audio setting pane.
- Since this option is enabled, we also need to stop rendering the AudioLevelIndicator component in order to reduce CPU usage.
