### PR TITLE
[PAT-1106] Prevent Jitsi from automatically refreshing the page after ending a session.

### DIFF
--- a/react/features/base/jwt/functions.js
+++ b/react/features/base/jwt/functions.js
@@ -145,3 +145,18 @@ export function validateJwt(jwt: string) {
 
     return errors;
 }
+
+
+/**
+ * Check whether the JWT token has expired.
+ *
+ * @param {string} jwt - Jwt token.
+ * @returns {boolean} - Whether JWT token has expired.
+ */
+export function isJwtTokenExpired(jwt: string) {
+    try {
+        return Date.now() >= jwtDecode(jwt).exp * 1000;
+    } catch (error) {
+        return true;
+    }
+}

--- a/react/features/base/jwt/functions.js
+++ b/react/features/base/jwt/functions.js
@@ -155,6 +155,7 @@ export function validateJwt(jwt: string) {
  */
 export function isJwtTokenExpired(jwt: string) {
     try {
+        // we need to *1000 here since jwtDecode(jwt).exp returns seconds not miliseconds
         return Date.now() >= jwtDecode(jwt).exp * 1000;
     } catch (error) {
         return true;


### PR DESCRIPTION
## Description
- [Linear Ticket](https://linear.app/jane/issue/PAT-1106/prevent-jitsi-from-automatically-refreshing-the-page-after-ending-a)

- Adds `isJwtTokenExpired` function to determine if jwt has expired
- Prevent `PageReloadOverlay` from continuously reloading the page automatically if jwt has expired.


### Release Risk Assessment
Low Risk

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce
1. Create an jitsi online appt
2. Copy and paste the JWT from the video chat url onto jwt.io, and modify its expiration time to make it expire.
<img width="290" alt="image" src="https://user-images.githubusercontent.com/24568041/231876230-8663ea4e-7356-426b-b60a-b43785b7e423.png">

3. Use the expired jwt to open Jitsi app
4. We should see a error notification pops up and `connection` related errors in the console
<img width="536" alt="image" src="https://user-images.githubusercontent.com/24568041/231876490-b3bbbe76-5a78-4714-b851-d318b655d524.png">
<img width="755" alt="image" src="https://user-images.githubusercontent.com/24568041/231876603-44084e72-3f25-467f-b57e-fd96c234a4b1.png">
5. wait for a few minutes, and Jitsi app should no longer automatically reload the page after showing the jwt or connection-related errors.

extra QA: we probably need a smoke test to ensure this PR won't break anything before releasing it.

### Fixed / Expected Behaviour
Wait for a few minutes, and Jitsi app should no longer automatically reload the page after showing the jwt or connection-related errors.


### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After