### PR TITLE
add github actions to repo to create and manage SEC CVE issues

### DIFF
--- a/.github/workflows/auto_create_linear_issues_for_dependabot.yml
+++ b/.github/workflows/auto_create_linear_issues_for_dependabot.yml
@@ -1,0 +1,21 @@
+name: Automatically Create Linear issues for Dependabot alerts
+
+on:
+  schedule:
+    - cron: '37 2 * * 1-5'
+  pull_request: {}
+  workflow_dispatch:
+    inputs:
+      time_period: 
+        description: 'Time period for fetched alerts'
+        type: number
+        required: false
+        default: 4
+
+jobs:
+  call-process-dependabot-alerts:
+    uses: janeapp/reusable-workflows/.github/workflows/process-dependabot-alerts.yml@main
+    with:
+      repo_name: video-chat
+      time_period: ${{ inputs.time_period || 4 }}
+    secrets: inherit

--- a/.github/workflows/keep_sec_cve_issues_in_sync_with_child_issues.yml
+++ b/.github/workflows/keep_sec_cve_issues_in_sync_with_child_issues.yml
@@ -1,0 +1,14 @@
+name: Keep SEC CVE issues in sync with dependabot and Child Issues
+
+on:
+  schedule:
+    - cron: '37 2 * * 1-5'
+  workflow_dispatch:
+
+
+jobs:
+  call-sec-cve-syncer:
+    uses: janeapp/reusable-workflows/.github/workflows/keep-sec-issues-in-sync-with-cve-issues.yml@main
+    with:
+      repo_name: video-chat
+    secrets: inherit


### PR DESCRIPTION
This PR adds two github actions to this Repository to automatically create linear issues for security vulnerabilities detected by Dependabot and also keeps the state and priorities of the child tickets in sync with their parent tickets.
