### PR TITLE
[PAT-1148] CVE-2022-31129: moment Upgrade to >= 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13196,9 +13196,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-duration-format": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1418.0.0+da6d04c2/lib-jitsi-meet.tgz",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
-    "moment": "2.29.1",
+    "moment": "2.29.4",
     "moment-duration-format": "2.2.2",
     "optional-require": "1.0.3",
     "promise.allsettled": "1.0.4",


### PR DESCRIPTION
## Description
- [Jira Ticket](https://jira-jane.atlassian.net/jira/software/c/projects/PAT/boards/53?selectedIssue=PAT-1148)

- Bump moment version to 2.29.4

### Release Risk Assessment
Low Risk

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce
Smoke test

### Fixed / Expected Behaviour


### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After
