### PR TITLE
[PAT-1291] Remove mentions of IP addresses and ports numbers from connection stats overlay

### DIFF
--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -652,9 +652,9 @@ class ConnectionStatsTable extends Component<Props> {
 
         if (!transport || transport.length === 0) {
             const NA = (
-                <tr key = 'address'>
+                <tr key = 'transport'>
                     <td>
-                        <span>{ t('connectionindicator.address') }</span>
+                        <span>{ t('connectionindicator.transport') }</span>
                     </td>
                     <td>
                         N/A
@@ -721,31 +721,6 @@ class ConnectionStatsTable extends Component<Props> {
 
         // First show remote statistics, then local, and then transport type.
         const tableRowConfigurations = [
-            {
-                additionalData,
-                data: data.remoteIP,
-                key: 'remoteaddress',
-                label: t('connectionindicator.remoteaddress',
-                    { count: data.remoteIP.length })
-            },
-            {
-                data: data.remotePort,
-                key: 'remoteport',
-                label: t('connectionindicator.remoteport',
-                        { count: transport.length })
-            },
-            {
-                data: data.localIP,
-                key: 'localaddress',
-                label: t('connectionindicator.localaddress',
-                    { count: data.localIP.length })
-            },
-            {
-                data: data.localPort,
-                key: 'localport',
-                label: t('connectionindicator.localport',
-                    { count: transport.length })
-            },
             {
                 data: data.transportType,
                 key: 'transport',


### PR DESCRIPTION
## Description

Remove mentions of local and remote user IP addresses and ports when users hover over their connection status indicator > more menu option. See before/after screenshots

https://jira-jane.atlassian.net/browse/PAT-1291

### Release Risk Assessment
Low Risk

### Demo Notes
N/A

## QA and Smoke Testing

- Verify IP addresses and ports do not show up in waiting room or in the call
- Just a smoke test on s5

### Fixed / Expected Behaviour

### Other Considerations
N/A

## Screenshots

Before / after of connection status info in the Waiting Room
![image](https://github.com/janeapp/video-chat/assets/88002018/d1bfd443-dc4e-4d08-a1d7-d01353a686fb)

Before / after of connection status info when users have joined a session
![image](https://github.com/janeapp/video-chat/assets/88002018/09614414-195b-45b0-8468-ac1b7a0f8ee4)
