### PR TITLE
[PAT-1371] add release script & app version

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,5 +177,6 @@
     "validate": "npm ls",
     "start": "make dev",
     "android": "react-native run-android"
-  }
+  },
+  "webAppVersion": "23.10.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -178,5 +178,5 @@
     "start": "make dev",
     "android": "react-native run-android"
   },
-  "webAppVersion": "23.10.0.0"
+  "webAppVersion": "23.10.1.0"
 }

--- a/react/features/analytics/handlers/JaneHandler.js
+++ b/react/features/analytics/handlers/JaneHandler.js
@@ -44,7 +44,7 @@ export default class JaneHandler extends AbstractHandler {
             'participant_type': participant.participant_type,
             'uid': this.uid,
             'browser_session_id': this.browserSessionId,
-            'jitsi_client_version': this.jitsiClientVersion
+            'app_version': this.jitsiClientVersion
         };
 
         if (navigator.product === 'ReactNative') {

--- a/react/features/analytics/handlers/JaneHandler.js
+++ b/react/features/analytics/handlers/JaneHandler.js
@@ -1,4 +1,4 @@
-import { getAppVersion, getBrowserSessionId } from '../../app/functions';
+import { getAppVersion, getBrowserSessionId, getClientVersion } from '../../app/functions';
 import { getJitsiMeetGlobalNS } from '../../base/util';
 
 import AbstractHandler from './AbstractHandler';
@@ -30,6 +30,7 @@ export default class JaneHandler extends AbstractHandler {
         this._participant = options.participant;
         this.uid = options.uid;
         this.browserSessionId = getBrowserSessionId();
+        this.jitsiClientVersion = getClientVersion();
 
     }
 
@@ -42,7 +43,8 @@ export default class JaneHandler extends AbstractHandler {
             'participant_id': participant.participant_id,
             'participant_type': participant.participant_type,
             'uid': this.uid,
-            'browser_session_id': this.browserSessionId
+            'browser_session_id': this.browserSessionId,
+            'jitsi_client_version': this.jitsiClientVersion
         };
 
         if (navigator.product === 'ReactNative') {

--- a/react/features/app/functions.native.js
+++ b/react/features/app/functions.native.js
@@ -56,3 +56,12 @@ export function getBrowserSessionId() {
 export function getAppVersion() {
     return DeviceInfo.getVersion();
 }
+
+/**
+ * Returns native app version defined by Jane.
+ *
+ * @returns {string}
+ */
+export function getClientVersion() {
+    return getAppVersion();
+}

--- a/react/features/app/functions.web.js
+++ b/react/features/app/functions.web.js
@@ -64,3 +64,13 @@ export function getBrowserSessionId() {
 export function getAppVersion() {
     return getName();
 }
+
+/**
+ * Returns web app version defined by Jane.
+ *
+ * @returns {string}
+ */
+export function getClientVersion() {
+    // eslint-disable-next-line no-undef
+    return process.env.APP_VERSION || '1.0';
+}

--- a/version_release.sh
+++ b/version_release.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+masterBranch=$branch
+currentVersion=`node -p "require('./package.json').webAppVersion"`
+
+
+if [ $branch == "master" ]; then
+  echo "Jitsi Release Script"
+  echo "The current release version is $currentVersion \n"
+
+  echo "Enter the release notes url"
+  read releaseNotesUrl
+  echo ""
+
+  v=( ${currentVersion//./ } )  # replace points, split version number into array
+
+  echo "What type of release is this?"
+  PS3='Please choose a type: '
+  releaseTypes=("Feature" "Patch")
+  select type in "${releaseTypes[@]}"; do
+    case $type in
+      "Feature")
+        echo "This is a Feature Release, updating Minor number \n"
+        ((v[2]++))
+        ((v[3] = 0))
+        break
+        ;;
+      "Patch")
+        echo "This is a BugFix/Patch Release, updating Patch number \n"
+        ((v[3]++))
+        break
+        ;;
+        *) echo "invalid option $REPLY";;
+      esac
+  done
+
+  # versionNumber rebuilds CalVer, eg v23.1.0.1, etc
+  year=$(date +%y) # 23, 24, 25 etc
+  month=$(date +%m) # 01, 02 ... 11, 12 etc
+
+  # if the current year and month are not the same as the previous version number, reset the patch and feature numbers
+  # since we are in a new month or year
+  if [ "$year$month" != "${v[0]}${v[1]}" ]; then
+    if [ "$type" == "Feature" ]; then
+      v[2]=1
+      v[3]=0
+    else # Patch
+      v[2]=0
+      v[3]=1
+    fi
+  fi
+
+  versionNumber="$year.$month.${v[2]}.${v[3]}"
+
+  echo "Is the version number correct? $versionNumber y/n"
+  read isCorrectVersion
+
+  if [ $isCorrectVersion == "y" ]; then
+    # establish branch and tag name variables
+    releaseBranch=release-$versionNumber
+    tagName=$versionNumber
+
+    echo "Creating release branch for $versionNumber"
+    git checkout -b $releaseBranch
+
+    echo "Incrementing version number"
+    sed -i '' "s/${currentVersion}/${versionNumber}/" package.json
+
+    echo "Creating release commit and tag"
+    git add package.json
+    git commit --allow-empty -m "Release $versionNumber" -m "$releaseNotesUrl"
+
+    git tag $tagName
+    git push origin $tagName
+
+    echo "Pushing release branch to remote origin"
+    git push --set-upstream origin $releaseBranch
+  else
+    echo "Please manually enter correct release version"
+    read customReleaseVersion
+    echo "Is the version number correct? v$customReleaseVersion y/n"
+    read confirmCustomVersion
+    if [ $confirmCustomVersion == "y" ]; then
+          # establish branch and tag name variables
+        versionNumber=$customReleaseVersion
+        releaseBranch=release-$versionNumber
+        tagName=$versionNumber
+
+        echo "Creating release branch for $versionNumber"
+        git checkout -b $releaseBranch
+
+        echo "Incrementing version number"
+        sed -i '' "s/${currentVersion}/${versionNumber}/" package.json
+
+        echo "Creating release commit and tag"
+        git add package.json
+        git commit --allow-empty -m "Release $versionNumber" -m "$releaseNotesUrl"
+
+        git tag $tagName
+        git push origin $tagName
+
+        echo "Pushing release branch to remote origin"
+        git push --set-upstream origin $releaseBranch
+    else
+      echo "Please begin release script again. No changes have been made."
+    fi
+  fi
+else
+  echo "Please make sure you are on main branch!"
+fi

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const process = require('process');
 const webpack = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+const { webAppVersion } = require('./package.json');
 const cacheVersionNumber = Math.random().toString(36)
 .substr(2, 5);
 
@@ -189,6 +190,9 @@ const config = {
             allowAsyncCycles: false,
             exclude: /node_modules/,
             failOnError: false
+        }),
+        new webpack.DefinePlugin({
+            'process.env.APP_VERSION': JSON.stringify(webAppVersion)
         }),
         new HtmlWebpackPlugin({
             jitsiLib: `libs/lib-jitsi-meet.min.js?v=${cacheVersionNumber}`,


### PR DESCRIPTION
## Description
- [Jira Ticket](https://jira-jane.atlassian.net/browse/PAT-1371)

- Adds release script
- Adds app client version to the webpack config script & analytics event



### Release Risk Assessment
Low Risk

### Demo Notes

## QA and Smoke Testing
### Steps to Reproduce

### Fixed / Expected Behaviour
- Run the command: `sh version_release.sh`. This should generate a release PR and automatically increment the version number.
<img width="998" alt="image" src="https://github.com/janeapp/video-chat/assets/24568041/bc3506b3-93b0-4e36-9080-54c17e9f6d03">

- Ensure that the analytics event parameters include the app_version field.
<img width="1283" alt="image" src="https://github.com/janeapp/video-chat/assets/24568041/ccbde15d-4e84-4992-9775-7ccc659abdf7">

### Other Considerations
> - Will this affect other parts of the app or views?
> - How can the success of this work be confirmed after release to production?
> - What QA have you already done?

## Screenshots
### Before
### After